### PR TITLE
Fix bug in monitoring for DDP mode and other typos

### DIFF
--- a/examples/capriccio/run_zeus.py
+++ b/examples/capriccio/run_zeus.py
@@ -141,7 +141,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Create a designated log directory inside `args.log_base` just for this run of Zeus.
     # Six types of outputs are generated.
-    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}.power.log`):
+    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}+gpu{device_id}.power.log`):
     #      Raw output of the Zeus power monitor.
     # 2. Profiling results (`bs{batch_size}.power.json`):
     #      Train-time average power consumption and throughput for each power limit,

--- a/examples/cifar100/run_zeus.py
+++ b/examples/cifar100/run_zeus.py
@@ -135,7 +135,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Create a designated log directory inside `args.log_base` just for this run of Zeus.
     # Six types of outputs are generated.
-    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}.power.log`):
+    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}+gpu{device_id}.power.log`):
     #      Raw output of the Zeus power monitor.
     # 2. Profiling results (`bs{batch_size}.power.json`):
     #      Train-time average power consumption and throughput for each power limit,

--- a/examples/imagenet/run_zeus.py
+++ b/examples/imagenet/run_zeus.py
@@ -88,7 +88,7 @@ def main(args: argparse.Namespace) -> None:
         profile_measure_iters=80,
     )
 
-    # Definition of the CIFAR100 job.
+    # Definition of the ImageNet job.
     # The `Job` class encloses all information needed to run training. The `command` parameter is
     # a command template. Curly-braced parameters are recognized by Zeus and automatically filled.
     job = Job(
@@ -125,7 +125,7 @@ def main(args: argparse.Namespace) -> None:
 
     # Create a designated log directory inside `args.log_base` just for this run of Zeus.
     # Six types of outputs are generated.
-    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}.power.log`):
+    # 1. Power monitor ouptut (`bs{batch_size}+e{epoch_num}+gpu{device_id}.power.log`):
     #      Raw output of the Zeus power monitor.
     # 2. Profiling results (`bs{batch_size}.power.json`):
     #      Train-time average power consumption and throughput for each power limit,

--- a/zeus/run/dataloader.py
+++ b/zeus/run/dataloader.py
@@ -755,7 +755,13 @@ class ZeusDataLoader(DataLoader):
         # Start monitors. Master process starts and records all monitors.
         for index in range(self.world_size):
             monitor = subprocess.Popen(
-                [self.monitor_path, self._power_log_path(index), "0", "100", index],
+                [
+                    self.monitor_path,
+                    self._power_log_path(index),
+                    "0",
+                    "100",
+                    str(index),
+                ],
             )
             self._log(f"[GPU_{index}] Zeus monitor started.")
             ZeusDataLoader.monitors.append(monitor)

--- a/zeus/run/dataloader.py
+++ b/zeus/run/dataloader.py
@@ -755,7 +755,7 @@ class ZeusDataLoader(DataLoader):
         # Start monitors. Master process starts and records all monitors.
         for index in range(self.world_size):
             monitor = subprocess.Popen(
-                [self.monitor_path, self._power_log_path(index), "0", "100"],
+                [self.monitor_path, self._power_log_path(index), "0", "100", index],
             )
             self._log(f"[GPU_{index}] Zeus monitor started.")
             ZeusDataLoader.monitors.append(monitor)

--- a/zeus/run/master.py
+++ b/zeus/run/master.py
@@ -240,7 +240,7 @@ class ZeusMaster:
 
         # Casting
         if not isinstance(stats["reached"], bool):
-            stats["reached"] = stats["reaached"].lower() == "true"
+            stats["reached"] = stats["reached"].lower() == "true"
 
         return float(stats["energy"]), float(stats["time"]), stats["reached"]
 


### PR DESCRIPTION
This PR fixes an important bug in monitoring at DDP mode: `device_id` is not specified when spawning Zeus monitors.
This bug will cause all the monitors to keep polling the same GPU.