### PR TITLE
Unpin Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "pandas",
     "scikit-learn",
     "nvidia-ml-py",
-    "pydantic<2",
+    "pydantic",
     "rich",
     "tyro",
     "fastapi[all]==0.87.0",
@@ -82,6 +82,7 @@ convention = "google"
 "**/__init__.py" = ["F401", "F403"]
 "zeus/optimizer/perseus/common.py" = ["N805"]
 "zeus/optimizer/perseus/server/router.py" = ["B008"]
+"zeus/util/pydantic_v1.py" = ["F403"]
 
 [tool.pytest.ini_options]
 addopts = "--numprocesses auto"

--- a/zeus/optimizer/perseus/common.py
+++ b/zeus/optimizer/perseus/common.py
@@ -23,7 +23,8 @@ from typing import Any, Optional
 
 import aiofiles
 import pandas as pd
-from pydantic import BaseModel, BaseSettings, Field, validator, PyObject
+
+from zeus.util.pydantic_v1 import BaseModel, BaseSettings, Field, validator, PyObject
 
 GET_SERVER_INFO_URL = "/info"
 REGISTER_JOB_URL = "/register_job"

--- a/zeus/optimizer/power_limit.py
+++ b/zeus/optimizer/power_limit.py
@@ -41,12 +41,12 @@ from pathlib import Path
 from abc import ABC, abstractmethod
 
 import pynvml
-from pydantic import BaseModel, PositiveInt, PositiveFloat
 
 from zeus.callback import Callback
 from zeus.monitor import ZeusMonitor
 from zeus.util.logging import get_logger
 from zeus.util.metric import zeus_cost
+from zeus.util.pydantic_v1 import BaseModel, PositiveInt, PositiveFloat
 
 from typing import TYPE_CHECKING
 
@@ -477,7 +477,6 @@ class GlobalPowerLimitOptimizer(Callback):
 # Only import HuggingFace Classes when type checking, to avoid hard dependency on HuggingFace Transformers
 if TYPE_CHECKING:
     from transformers import (
-        TrainerCallback,
         TrainingArguments,
         TrainerState,
         TrainerControl,

--- a/zeus/util/pydantic_v1.py
+++ b/zeus/util/pydantic_v1.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2023 Jae-Won Chung <jwnchung@umich.edu>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compatibility layer for Pydantic v1 and v2.
+
+We don't want to pin any specific version of Pydantic. With this, we can
+import things from `zeus.util.pydantic_v1` and always use the V1 API
+regardless of the installed version of Pydantic.
+
+Inspired by Deepspeed:
+https://github.com/microsoft/DeepSpeed/blob/5d754606/deepspeed/pydantic_v1.py
+"""
+
+try:
+    from pydantic.v1 import *
+except ImportError:
+    from pydantic import *


### PR DESCRIPTION
This PR introduces the `zeus.util.pydantic_v1` compatibility layer to allow the user to install any version of Pydantic (V1 or V2).

Closes #35