### PR TITLE
Fix: Align parameters of setGpuLockedClocks to NVML API

### DIFF
--- a/zeus/device/gpu.py
+++ b/zeus/device/gpu.py
@@ -236,7 +236,7 @@ class GPU(abc.ABC):
 
     @abc.abstractmethod
     def setGpuLockedClocks(
-        self, index: int, minMemClockMHz: int, maxMemClockMHz: int
+        self, index: int, minGpuClockMHz: int, maxGpuClockMHz: int
     ) -> None:
         """Lock the GPU clock to a specified range. Units: MHz."""
         pass
@@ -377,10 +377,10 @@ class NVIDIAGPU(GPU):
 
     @_handle_nvml_errors
     def setGpuLockedClocks(
-        self, index: int, minMemClockMHz: int, maxMemClockMHz: int
+        self, index: int, minGpuClockMHz: int, maxGpuClockMHz: int
     ) -> None:
         """Locks the GPU clock of the specified GPU to a range defined by the minimum and maximum GPU clock frequencies. Units: MHz."""
-        pynvml.nvmlDeviceSetGpuLockedClocks(self.handle, minMemClockMHz, maxMemClockMHz)
+        pynvml.nvmlDeviceSetGpuLockedClocks(self.handle, minGpuClockMHz, maxGpuClockMHz)
 
     @_handle_nvml_errors
     def resetMemoryLockedClocks(self) -> None:
@@ -527,13 +527,13 @@ class AMDGPU(GPU):
 
     @_handle_amdsmi_errors
     def setGpuLockedClocks(
-        self, index: int, minMemClockMHz: int, maxMemClockMHz: int
+        self, index: int, minGpuClockMHz: int, maxGpuClockMHz: int
     ) -> None:
         """Locks the GPU clock of the specified GPU to a range defined by the minimum and maximum GPU clock frequencies.  Units: MHz."""
         amdsmi.amdsmi_set_gpu_clk_range(
             self.handle,
-            minMemClockMHz,
-            maxMemClockMHz,
+            minGpuClockMHz,
+            maxGpuClockMHz,
             clk_type=amdsmi.AMDSMI_CLK_TYPE_GFX,
         )
 
@@ -649,10 +649,10 @@ class GPUs(abc.ABC):
         return self.gpus[index].getName()
 
     def setGpuLockedClocks(
-        self, index: int, minMemClockMHz: int, maxMemClockMHz: int
+        self, index: int, minGpuClockMHz: int, maxGpuClockMHz: int
     ) -> None:
         """Locks the GPU clock of the specified GPU to a range defined by the minimum and maximum GPU clock frequencies. Units: MHz."""
-        self.gpus[index].setGpuLockedClocks(minMemClockMHz, maxMemClockMHz)
+        self.gpus[index].setGpuLockedClocks(minGpuClockMHz, maxGpuClockMHz)
 
     def resetMemoryLockedClocks(self, index: int) -> None:
         """Resets the memory locked clocks of the specified GPU to their default values."""


### PR DESCRIPTION
Align papameters of `setGpuLockedClocks` in `zeus/device/gpu.py` to [NVML API](https://docs.nvidia.com/deploy/nvml-api/group__nvmlDeviceCommands.html#group__nvmlDeviceCommands_1gc9b58cd685f4deee575400e2e6ac76cb) 

See details at #48.