### PR TITLE
Add CPU in devices

### DIFF
--- a/zeus/device/cpu/__init__.py
+++ b/zeus/device/cpu/__init__.py
@@ -1,0 +1,24 @@
+from zeus.device.cpu.common import CPUs, ZeusCPUInitError
+from zeus.device.cpu.intel import rapl_is_available, INTELCPUs
+
+_cpus: CPUs | None = None
+
+def get_cpus() -> CPUs:
+    """Initialize and return a singleton CPU monitoring object for INTEL CPUs.
+
+    The function returns a CPU management object that aims to abstract the underlying CPU monitoring libraries
+    (RAPL for Intel CPUs).
+
+    This function attempts to initialize CPU mointoring using RAPL. If this attempt fails, it raises 
+    a ZeusErrorInit exception.
+    """
+    global _cpus
+    if _cpus is not None:
+        return _cpus
+    if rapl_is_available():
+        _cpus = INTELCPUs()
+        return _cpus
+    else:
+        raise ZeusCPUInitError(
+            "RAPL unvailable Failed to initialize CPU management library."
+        )

--- a/zeus/device/cpu/common.py
+++ b/zeus/device/cpu/common.py
@@ -1,0 +1,99 @@
+"""Error wrappers and classes common to all CPU vendors."""
+
+from __future__ import annotations
+
+import abc
+from typing import Sequence
+
+from zeus.device.exception import ZeusBaseCPUError
+
+
+class ZeusCPUInitError(ZeusBaseCPUError):
+    """Import error or CPU library initialization failures."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+class ZeusCPUNoPermissionError(ZeusBaseCPUError):
+    """Zeus CPU exception class Wrapper for No Permission to perform CPU operation."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+class ZeusCPUNotFoundError(ZeusBaseCPUError):
+    """Zeus CPU exception class Wrapper for Not Found CPU."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+class CPU(abc.ABC):
+    """Abstract base class for CPU management.
+
+    This class defines the interface for interacting with CPUs, subclasses should implement the methods to interact with specific CPU libraries.
+    """
+
+    def __init__(self, cpu_index: int) -> None:
+        """Initialize the CPU with a specified index."""
+        self.cpu_index = cpu_index
+
+    @abc.abstractmethod
+    def getTotalEnergyConsumption(self) -> int:
+        """Returns the total energy consumption of the specified powerzone. Units: mJ."""
+        pass
+
+    @abc.abstractmethod
+    def supportsGetSubpackageEnergyConsumption(self) -> bool:
+        """Returns True if the specified CPU powerzone supports retrieving the subpackage energy consumption."""
+        pass
+
+    @abc.abstractmethod
+    def getSubpackageEnergyConsumption(self) -> int:
+        """Returns the energy consumption of the subpackages inside the specified powerzone. Units: mJ."""
+        pass
+
+
+class CPUs(abc.ABC):
+    """An abstract base class for CPU manager object.
+
+    This class defines the essential interface and common functionality for CPU management, instantiating multiple `CPU` objects for each CPU being tracked.
+    Forwards the call for a specific method to the corresponding CPU object.
+    """
+
+    @abc.abstractmethod
+    def __init__(self) -> None:
+        """Initializes the CPU management library to communicate with the CPU driver and sets up tracking for specified CPUs."""
+        pass
+
+    @abc.abstractmethod
+    def __del__(self) -> None:
+        """Shuts down the CPU monitoring library to release resources and clean up."""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def cpus(self) -> Sequence[CPU]:
+        """Returns a list of CPU objects being tracked."""
+        pass
+
+    def getTotalEnergyConsumption(self, index: int) -> int:
+        """Returns the total energy consumption of the specified powerzone. Units: mJ."""
+        return self.cpus[index].getTotalEnergyConsumption()
+
+    def supportsGetSubpackageEnergyConsumption(self, index: int) -> bool:
+        """Returns True if the specified CPU powerzone supports retrieving the subpackage energy consumption."""
+        return self.cpus[index].supportsGetSubpackageEnergyConsumption()
+
+    def getSubpackageEnergyConsumption(self, index: int) -> int:
+        """Returns the energy consumption of the subpackages inside the specified powerzone. Units: mJ."""
+        return self.cpus[index].getSubpackageEnergyConsumption()
+
+    def __len__(self) -> int:
+        """Returns the number of CPUs being tracked."""
+        return len(self.cpus)
+

--- a/zeus/device/cpu/intel.py
+++ b/zeus/device/cpu/intel.py
@@ -1,0 +1,151 @@
+"""Intel CPUs."""
+
+from __future__ import annotations
+
+import functools
+import os
+import contextlib
+from typing import Sequence, Dict, List
+
+import zeus.device.cpu.common as cpu_common
+from zeus.device.exception import ZeusBaseCPUError
+from zeus.utils.logging import get_logger
+
+logger = get_logger(name=__name__)
+
+DIR: str = "/sys/class/powercap/intel-rapl"
+
+def rapl_is_available() -> bool:
+    """Check if RAPL is available."""
+    if not os.path.exists(DIR):
+        logger.info("RAPL is not supported on this CPU.")
+        return False
+    logger.info("RAPL is available.")
+    return True
+
+class ZeusRAPLNotSupportedError(ZeusBaseCPUError):
+    """Zeus CPU exception class Wrapper for RAPL not supported on CPU."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+class ZeusRAPLFileInitError(ZeusBaseCPUError):
+    """Zeus CPU exception class Wrapper for RAPL file initialization error on CPU."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+class RAPLFile:
+    """RAPL File class for each RAPL file.
+
+    This class defines the interface for interacting with a RAPL file for a package. A package can
+    be a CPU or DRAM
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path: str = path
+        self.energy_uj_path: str = os.path.join(path, "energy_uj")
+        try:
+            with open(os.path.join(path, "name"), 'r') as name_file:
+                self.name: str = name_file.read().strip()
+        except:
+            raise ZeusRAPLFileInitError(
+                "Error reading package name"
+            )
+        try:
+            with open(self.energy_uj_path) as energy_file:
+                self.last_energy: int = int(float(energy_file.read().strip())/10**3)
+        except:
+            raise ZeusRAPLFileInitError(
+                "Error reading package energy"
+            )
+        try:
+            with open(os.path.join(path, "max_energy_range_uj"), 'r') as max_energy_file:
+                self.max_energy_range_uj: int = int(float(max_energy_file.read().strip())/10**3)
+        except:
+            raise ZeusRAPLFileInitError(
+                "Error reading package max energy range"
+            )
+
+    def __str__(self) -> str:
+        return f"Path: {self.path}\nEnergy_uj_path: {self.energy_uj_path}\nName: {self.name}\
+        \nLast_energy: {self.last_energy}\nMax_energy: {self.max_energy_range_uj}"
+
+    def read(self) -> int:
+        with open(self.energy_uj_path) as energy_file:
+            self.last_energy = int(float(energy_file.read().strip())/10**3)
+        return self.last_energy
+
+    def read_delta(self) -> int:
+        last_energy: int = self.last_energy
+        new_energy: int = self.read()
+        if new_energy < last_energy:
+            return new_energy + self.max_energy_range_uj - last_energy
+        return new_energy - last_energy
+
+class INTELCPU(cpu_common.CPU):
+    """Control a Single Intel CPU using RAPL interface."""
+
+    def __init__(self, cpu_index: int) -> None:
+        """Initialize the Intel CPU with a specified index."""
+        super().__init__(cpu_index)
+        self._get_powerzone()
+
+    _exception_map = {
+        FileNotFoundError: cpu_common.ZeusCPUNotFoundError,
+        PermissionError: cpu_common.ZeusCPUNoPermissionError,
+        OSError: cpu_common.ZeusCPUInitError,
+    }
+
+    def _get_powerzone(self) -> None:
+        self.path = os.path.join(DIR, f"intel-rapl:{self.cpu_index}")
+        self.rapl_file: RAPLFile = RAPLFile(self.path)
+        self.subpackages: List = []
+        for dir in os.listdir(self.path):
+            if "intel-rapl" in dir:
+                self.subpackages.append(RAPLFile(os.path.join(self.path, dir)))
+
+    def getTotalEnergyConsumption(self) -> int:
+        """Returns the total energy consumption of the specified powerzone. Units: mJ."""
+        return self.rapl_file.read()
+
+    def supportsGetSubpackageEnergyConsumption(self) -> bool:
+        """Returns True if the specified CPU powerzone supports retrieving the subpackage energy consumption."""
+        return len(self.subpackages)!=0
+
+    def getSubpackageEnergyConsumption(self) -> int:
+        """Returns the energy consumption of the subpackages inside the specified powerzone. Units: mJ."""
+        raise NotImplementedError("Subpackage readings not implemented")
+        return 0
+
+
+class INTELCPUs(cpu_common.CPUs):
+    """Intel CPU Manager object, containing individual IntelCPU objects, abstracting RAPL calls and handling related exceptions."""
+
+    def __init__(self) -> None:
+        """Instantiates IntelCPUs object, setting up tracking for specified Intel CPUs.
+        """
+        if not rapl_is_available():
+            raise ZeusRAPLNotSupportedError("RAPL is not supported on this CPU.")
+        self._init_cpus()
+
+    @property
+    def cpus(self) -> Sequence[cpu_common.CPU]:
+        """Returns a list of CPU objects being tracked."""
+        return self._cpus
+
+    def _init_cpus(self) -> None:
+        """Initialize all Intel CPUs."""
+        self._cpus = []
+        for index in range(2):
+            try:
+                self._cpus.append(INTELCPU(index))
+            except:
+                continue
+
+    def __del__(self) -> None:
+        """Shuts down the Intel CPU monitoring."""
+        with contextlib.suppress(Exception):
+            logger.info("Shutting down Intel CPU monitoring.")

--- a/zeus/device/exception.py
+++ b/zeus/device/exception.py
@@ -8,3 +8,10 @@ class ZeusBaseGPUError(ZeusBaseError):
     def __init__(self, message: str) -> None:
         """Initialize Base Zeus Exception."""
         super().__init__(message)
+
+class ZeusBaseCPUError(ZeusBaseError):
+    """Zeus base CPU exception class."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Base Zeus Exception."""
+        super().__init__(message)


### PR DESCRIPTION
### Description
This is pull request is the first of a two part addition to extend `ZeusMonitor` to allow CPU energy consumption monitoring.

### Additions
A new cpu directory was added to devices that contains

- `get_cpus`: Returns a `CPUs` singleton monitoring object. Raises and error if unable to initialize the object
- `CPUs`: CPU monitoring object that exposes `getTotalEnergyConsumption`. Currently only supports Intel CPUs with RAPL support.

### Note
CPU subpackage not implemented for now as I didn't know how `ZeusMonitor` would interact with it. Will be implemented in a later pull request.