### PR TITLE
Fix CPU measurements so DRAM isn't included in package reading

### DIFF
--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -141,7 +141,6 @@ class RAPLCPU(cpu_common.CPU):
         dram_mj = None
         if self.dram is not None:
             dram_mj = self.dram.read()
-            cpu_mj -= dram_mj
         return CpuDramMeasurement(cpu_mj=cpu_mj, dram_mj=dram_mj)
 
     def supportsGetDramEnergyConsumption(self) -> bool:


### PR DESCRIPTION
CPU energy_uj readings of a package (intel-rapl:x) and subpackage (intel-rapl:x:y) readings are separate and there is no need to subtract the subpackage reading from the parent package reading.