### PR TITLE
Add jax support in CUDA sync

### DIFF
--- a/examples/jax/simple_monitoring.py
+++ b/examples/jax/simple_monitoring.py
@@ -1,0 +1,35 @@
+import time
+import jax
+import jax.numpy as jnp
+from zeus.monitor import ZeusMonitor
+
+@jax.jit
+def mat_prod(B):
+    """ Dummy example to make GPU warm with a jitting"""
+    A = jnp.ones((1000, 1000))
+    return A @ B
+
+if __name__ == "__main__":
+    # Time/Energy measurements for four GPUs will begin and end at the same time.
+    gpu_indices = [0]
+
+    monitor = ZeusMonitor(gpu_indices=gpu_indices, backend="jax")
+
+    # Mark the beginning of a measurement window. You can use any string
+    # as the window name, but make sure it's unique.
+    monitor.begin_window("all_computations")
+
+    # Actual work
+    key = jax.random.PRNGKey(0)
+    B = jax.random.uniform(key, (1000, 1000))
+    for i in range(100):
+        B = mat_prod(B)
+
+    # Mark the end of a measurement window and retrieve the measurment result.
+    result = monitor.end_window("all_computations")
+
+    # Print the measurement result.
+    print(f"Training took {result.time} seconds.")
+    print(f"Training consumed {result.total_energy} Joules.")
+    for gpu_idx, gpu_energy in result.gpu_energy.items():
+        print(f"GPU {gpu_idx} consumed {gpu_energy} Joules.")

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -160,6 +160,7 @@ class ZeusMonitor:
         cpu_indices: list[int] | None = None,
         approx_instant_energy: bool = False,
         log_file: str | Path | None = None,
+        backend: str | None = "torch"
     ) -> None:
         """Instantiate the monitor.
 
@@ -179,6 +180,7 @@ class ZeusMonitor:
                 instantaneous power consumption with the window's execution time. This should
                 be a better estimate than zero, but it's still an approximation.
             log_file: Path to the log CSV file. If `None`, logging will be disabled.
+            backend: The backend framework. Defaults to `torch`
         """
         # Save arguments.
         self.approx_instant_energy = approx_instant_energy
@@ -250,6 +252,8 @@ class ZeusMonitor:
         else:
             self.power_monitor = None
 
+        self.backend = backend
+
     def _get_instant_power(self) -> tuple[dict[int, float], float]:
         """Measure the power consumption of all GPUs at the current time."""
         power_measurement_start_time: float = time()
@@ -274,7 +278,7 @@ class ZeusMonitor:
         # Call cudaSynchronize to make sure we freeze at the right time.
         if sync_cuda:
             for gpu_index in self.gpu_indices:
-                cuda_sync(gpu_index)
+                cuda_sync(gpu_index, self.backend)
 
         # Freeze the start time of the profiling window.
         timestamp: float = time()
@@ -338,7 +342,7 @@ class ZeusMonitor:
         # Call cudaSynchronize to make sure we freeze at the right time.
         if sync_cuda:
             for gpu_index in self.gpu_indices:
-                cuda_sync(gpu_index)
+                cuda_sync(gpu_index, self.backend)
 
         # If the measurement window is cancelled, return an empty Measurement object.
         if cancel:

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -160,7 +160,7 @@ class ZeusMonitor:
         cpu_indices: list[int] | None = None,
         approx_instant_energy: bool = False,
         log_file: str | Path | None = None,
-        backend: str | None = "torch",
+        backend: str = "torch",
     ) -> None:
         """Instantiate the monitor.
 

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -160,7 +160,7 @@ class ZeusMonitor:
         cpu_indices: list[int] | None = None,
         approx_instant_energy: bool = False,
         log_file: str | Path | None = None,
-        backend: str | None = "torch"
+        backend: str | None = "torch",
     ) -> None:
         """Instantiate the monitor.
 

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -186,6 +186,7 @@ class ZeusMonitor:
         """
         # Save arguments.
         self.approx_instant_energy = approx_instant_energy
+        self.backend: Literal["torch", "jax"] = backend
 
         # Get gpus
         try:
@@ -253,8 +254,6 @@ class ZeusMonitor:
             )
         else:
             self.power_monitor = None
-
-        self.backend = backend
 
     def _get_instant_power(self) -> tuple[dict[int, float], float]:
         """Measure the power consumption of all GPUs at the current time."""

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import os
+from typing import Literal
 from time import time
 from pathlib import Path
 from dataclasses import dataclass
@@ -160,7 +161,7 @@ class ZeusMonitor:
         cpu_indices: list[int] | None = None,
         approx_instant_energy: bool = False,
         log_file: str | Path | None = None,
-        backend: str = "torch",
+        backend: Literal["torch", "jax"] = "torch",
     ) -> None:
         """Instantiate the monitor.
 
@@ -180,7 +181,8 @@ class ZeusMonitor:
                 instantaneous power consumption with the window's execution time. This should
                 be a better estimate than zero, but it's still an approximation.
             log_file: Path to the log CSV file. If `None`, logging will be disabled.
-            backend: The backend framework. Defaults to `torch`
+            backend: Deep learning framework to use to synchronize GPU computations.
+                Defaults to `"torch"`, in which case `torch.cuda.synchronize` will be used.
         """
         # Save arguments.
         self.approx_instant_energy = approx_instant_energy

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -57,7 +57,7 @@ def jax_is_available():
         return False
 
 
-def cuda_sync(device: int | None = None, backend: str | None = "torch") -> None:
+def cuda_sync(device: int | None = None, backend: str = "torch") -> None:
     """Synchronize CPU with CUDA.
 
     Note: `cupy.cuda.Device.synchronize` may be a good choice to make

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -41,22 +41,20 @@ def torch_is_available():
         logger.info("PyTorch is not available.")
         return False
 
+
 @lru_cache(maxsize=1)
 def jax_is_available():
     """Check if JAX is available."""
     try:
         import jax
 
-        assert (
-            jax.devices('gpu')
-        ), "JAX is available but does not have CUDA support."
+        assert jax.devices("gpu"), "JAX is available but does not have CUDA support."
         MODULE_CACHE["jax"] = jax
         logger.info("JAX with CUDA support is available.")
         return True
     except ImportError:
         logger.info("JAX is not available")
         return False
-        
 
 
 def cuda_sync(device: int | None = None, backend: str | None = "torch") -> None:
@@ -71,15 +69,19 @@ def cuda_sync(device: int | None = None, backend: str | None = "torch") -> None:
     """
     if backend == "torch" and torch_is_available():
         torch = MODULE_CACHE["torch"]
-        synchronize_cuda_fn = lambda device: torch.cuda.synchronize(device)
+
+        def synchronize_cuda_fn(device):
+            torch.cuda.synchronize(device)
+
     elif backend == "jax" and jax_is_available():
         jax = MODULE_CACHE["jax"]
-        synchronize_cuda_fn = lambda device: (jax.device_put(0., device=jax.devices('gpu')[device]) + 0).block_until_ready() 
+
+        def synchronize_cuda_fn(device):
+            (
+                jax.device_put(0.0, device=jax.devices("gpu")[device]) + 0
+            ).block_until_ready()
+
     else:
         raise RuntimeError("No framework is available.")
 
     synchronize_cuda_fn(device)
-
-    return
-
-

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -74,18 +74,12 @@ def cuda_sync(device: int | None = None, backend: str = "torch") -> None:
     if backend == "torch" and torch_is_available(ensure_available=True):
         torch = MODULE_CACHE["torch"]
 
-        def synchronize_cuda_fn(device):
-            torch.cuda.synchronize(device)
+        torch.cuda.synchronize(device)
 
     elif backend == "jax" and jax_is_available(ensure_available=True):
         jax = MODULE_CACHE["jax"]
 
-        def synchronize_cuda_fn(device):
-            (
-                jax.device_put(0.0, device=jax.devices("gpu")[device]) + 0
-            ).block_until_ready()
+        (jax.device_put(0.0, device=None if device is None else jax.devices("gpu")[device]) + 0).block_until_ready()
 
     else:
         raise RuntimeError("No framework is available.")
-
-    synchronize_cuda_fn(device)

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import types
+from typing import Literal
 from functools import lru_cache
 
 from zeus.utils.logging import get_logger
@@ -48,7 +49,7 @@ def torch_is_available(ensure_available: bool = False):
 def jax_is_available(ensure_available: bool = False):
     """Check if JAX is available."""
     try:
-        import jax
+        import jax  # type: ignore
 
         assert jax.devices("gpu"), "JAX is available but does not have CUDA support."
         MODULE_CACHE["jax"] = jax
@@ -61,7 +62,9 @@ def jax_is_available(ensure_available: bool = False):
         return False
 
 
-def cuda_sync(device: int | None = None, backend: str = "torch") -> None:
+def cuda_sync(
+    device: int | None = None, backend: Literal["torch", "jax"] = "torch"
+) -> None:
     """Synchronize CPU with CUDA.
 
     Note: `cupy.cuda.Device.synchronize` may be a good choice to make
@@ -69,7 +72,8 @@ def cuda_sync(device: int | None = None, backend: str = "torch") -> None:
 
     Args:
         device: The device to synchronize.
-        backend: The backend framework. Defaults to `torch`
+        backend: Deep learning framework to use to synchronize GPU computations.
+            Defaults to `"torch"`, in which case `torch.cuda.synchronize` will be used.
     """
     if backend == "torch" and torch_is_available(ensure_available=True):
         torch = MODULE_CACHE["torch"]

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -40,7 +40,7 @@ def torch_is_available(ensure_available: bool = False):
     except ImportError as e:
         logger.info("PyTorch is not available.")
         if ensure_available:
-            raise RunTimeError("Failed to import Pytorch") from e
+            raise RuntimeError("Failed to import Pytorch") from e
         return False
 
 
@@ -57,7 +57,7 @@ def jax_is_available(ensure_available: bool = False):
     except ImportError as e:
         logger.info("JAX is not available")
         if ensure_available:
-            raise RunTimeError("Failed to import JAX") from e
+            raise RuntimeError("Failed to import JAX") from e
         return False
 
 
@@ -79,7 +79,12 @@ def cuda_sync(device: int | None = None, backend: str = "torch") -> None:
     elif backend == "jax" and jax_is_available(ensure_available=True):
         jax = MODULE_CACHE["jax"]
 
-        (jax.device_put(0.0, device=None if device is None else jax.devices("gpu")[device]) + 0).block_until_ready()
+        (
+            jax.device_put(
+                0.0, device=None if device is None else jax.devices("gpu")[device]
+            )
+            + 0
+        ).block_until_ready()
 
     else:
         raise RuntimeError("No framework is available.")


### PR DESCRIPTION
Hi,

Following #28, some straightforward changes to be able to use JAX with zeus.

This directly mimics what is currently done for the torch backend, so this does not bring abstraction to the `cuda_sync` function. Moreover as JAX currently lacks an equivalent of `torch.cuda.synchronize` (as far as I know), we resort the the solution appearing in https://github.com/google/jax/issues/4335#issuecomment-695784736

Tell me what you think