### PR TITLE
Rapl permission handling in docker container

### DIFF
--- a/capriccio/generate.py
+++ b/capriccio/generate.py
@@ -9,7 +9,6 @@ Usage:
     python capriccio/generate.py /path/to/sentiment140.json
 """
 
-
 import argparse
 import os
 import warnings

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -43,9 +43,9 @@ class MockCPU(CPU):
         """Returns the total energy consumption of the specified powerzone. Units: mJ."""
         return CpuDramMeasurement(
             cpu_mj=float(next(self.cpu_energy)),
-            dram_mj=float(next(self.dram_energy))
-            if self.dram_energy is not None
-            else None,
+            dram_mj=(
+                float(next(self.dram_energy)) if self.dram_energy is not None else None
+            ),
         )
 
     def supportsGetDramEnergyConsumption(self):
@@ -281,9 +281,11 @@ def test_monitor(pynvml_mock, mock_gpus, mocker: MockerFixture, tmp_path: Path):
             for i in range(len(monitor.cpu_indices))
         }
         assert monitor.measurement_states[name].dram_energy == {
-            i: pytest.approx((200 + 5 * (begin_time - 4)) / 1000.0)
-            if i % 2 == 0
-            else None
+            i: (
+                pytest.approx((200 + 5 * (begin_time - 4)) / 1000.0)
+                if i % 2 == 0
+                else None
+            )
             for i in range(0, len(monitor.cpu_indices), 2)
         }
         pynvml_mock.nvmlDeviceGetTotalEnergyConsumption.assert_has_calls(

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -147,6 +147,12 @@ class ZeusRAPLFileInitError(ZeusBaseCPUError):
         """Initialize Zeus Exception."""
         super().__init__(message)
 
+class ZeusRAPLPermissionError(ZeusBaseCPUError):
+    """Zeus GPU exception that wraps No Permission to perform GPU operation."""
+
+    def __init__(self, message: str) -> None:
+        """Intialize the exception object."""
+        super().__init__(message)
 
 class RAPLFile:
     """RAPL File class for each RAPL file.
@@ -169,6 +175,10 @@ class RAPLFile:
                 self.last_energy = float(energy_file.read().strip())
         except FileNotFoundError as err:
             raise ZeusRAPLFileInitError("Error reading package energy") from err
+        except PermissionError as err:
+            raise ZeusRAPLPermissionError(
+                "Can't read file due to permission error"
+            ) from err
         try:
             with open(
                 os.path.join(path, "max_energy_range_uj"), "r"

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -147,12 +147,14 @@ class ZeusRAPLFileInitError(ZeusBaseCPUError):
         """Initialize Zeus Exception."""
         super().__init__(message)
 
+
 class ZeusRAPLPermissionError(ZeusBaseCPUError):
     """Zeus GPU exception that wraps No Permission to perform GPU operation."""
 
     def __init__(self, message: str) -> None:
         """Intialize the exception object."""
         super().__init__(message)
+
 
 class RAPLFile:
     """RAPL File class for each RAPL file.

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -32,6 +32,11 @@ logger = get_logger(name=__name__)
 
 RAPL_DIR = "/sys/class/powercap/intel-rapl"
 
+# Location of RAPL files when in a docker container. See
+# https://ml.energy/zeus/getting_started/#system-privileges for more details
+CONTAINER_RAPL_DIR = "/zeus_sys/class/powercap/intel-rapl"
+
+
 # Assuming a maximum power draw of 1000 Watts when we are polling every 0.1 seconds, the maximum
 # amount the RAPL counter would increase
 RAPL_COUNTER_MAX_INCREASE = 1000 * 1e6 * 0.1
@@ -125,7 +130,7 @@ def _polling_process(
 @lru_cache(maxsize=1)
 def rapl_is_available() -> bool:
     """Check if RAPL is available."""
-    if not os.path.exists(RAPL_DIR):
+    if not os.path.exists(RAPL_DIR) and not os.path.exists(CONTAINER_RAPL_DIR):
         logger.info("RAPL is not supported on this CPU.")
         return False
     logger.info("RAPL is available.")
@@ -215,9 +220,10 @@ class RAPLFile:
 class RAPLCPU(cpu_common.CPU):
     """Control a single CPU that supports RAPL."""
 
-    def __init__(self, cpu_index: int) -> None:
+    def __init__(self, cpu_index: int, rapl_dir: str) -> None:
         """Initialize the Intel CPU with a specified index."""
         super().__init__(cpu_index)
+        self.rapl_dir = rapl_dir
         self._get_powerzone()
 
     _exception_map = {
@@ -227,7 +233,7 @@ class RAPLCPU(cpu_common.CPU):
     }
 
     def _get_powerzone(self) -> None:
-        self.path = os.path.join(RAPL_DIR, f"intel-rapl:{self.cpu_index}")
+        self.path = os.path.join(self.rapl_dir, f"intel-rapl:{self.cpu_index}")
         self.rapl_file: RAPLFile = RAPLFile(self.path)
         self.dram: RAPLFile | None = None
         for dir in os.listdir(self.path):
@@ -262,6 +268,8 @@ class RAPLCPUs(cpu_common.CPUs):
         """Instantiates IntelCPUs object, setting up tracking for specified Intel CPUs."""
         if not rapl_is_available():
             raise ZeusRAPLNotSupportedError("RAPL is not supported on this CPU.")
+
+        self.rapl_dir = RAPL_DIR if os.path.exists(RAPL_DIR) else CONTAINER_RAPL_DIR
         self._init_cpus()
 
     @property
@@ -272,10 +280,10 @@ class RAPLCPUs(cpu_common.CPUs):
     def _init_cpus(self) -> None:
         """Initialize all Intel CPUs."""
         self._cpus = []
-        for dir in sorted(glob(f"{RAPL_DIR}/intel-rapl:*")):
+        for dir in sorted(glob(f"{self.rapl_dir}/intel-rapl:*")):
             parts = dir.split(":")
             if len(parts) > 1 and parts[1].isdigit():
-                self._cpus.append(RAPLCPU(int(parts[1])))
+                self._cpus.append(RAPLCPU(int(parts[1]), self.rapl_dir))
 
     def __del__(self) -> None:
         """Shuts down the Intel CPU monitoring."""

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -176,7 +176,7 @@ class RAPLFile:
         except FileNotFoundError as err:
             raise ZeusRAPLFileInitError("Error reading package energy") from err
         except PermissionError as err:
-            raise ZeusRAPLPermissionError(
+            raise cpu_common.ZeusCPUNoPermissionError(
                 "Can't read file due to permission error"
             ) from err
         try:

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -10,13 +10,12 @@ from pathlib import Path
 from dataclasses import dataclass
 from functools import cached_property
 
-from zeus.device.cpu.rapl import ZeusRAPLPermissionError
 from zeus.monitor.power import PowerMonitor
 from zeus.utils.logging import get_logger
 from zeus.utils.framework import sync_execution as sync_execution_fn
 from zeus.device import get_gpus, get_cpus
 from zeus.device.gpu.common import ZeusGPUInitError, EmptyGPUs
-from zeus.device.cpu.common import ZeusCPUInitError, EmptyCPUs
+from zeus.device.cpu.common import ZeusCPUInitError, ZeusCPUNoPermissionError, EmptyCPUs
 
 logger = get_logger(__name__)
 
@@ -187,10 +186,10 @@ class ZeusMonitor:
             self.cpus = get_cpus()
         except ZeusCPUInitError:
             self.cpus = EmptyCPUs()
-        except ZeusRAPLPermissionError as err:
+        except ZeusCPUNoPermissionError as err:
             if cpu_indices:
                 raise RuntimeError(
-                    "SYS_ADMIN capability is required to read RAPL files. See "
+                    "root capability is required to read RAPL files. See "
                     "https://ml.energy/zeus/getting_started/#system-privileges "
                     "for more information or disable CPU measurement by passing cpu_indices=[] to "
                     "ZeusMonitor"

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from functools import cached_property
 
+from zeus.device.cpu.rapl import ZeusRAPLPermissionError
 from zeus.monitor.power import PowerMonitor
 from zeus.utils.logging import get_logger
 from zeus.utils.framework import sync_execution as sync_execution_fn
@@ -186,6 +187,13 @@ class ZeusMonitor:
             self.cpus = get_cpus()
         except ZeusCPUInitError:
             self.cpus = EmptyCPUs()
+        except ZeusRAPLPermissionError as err:
+            raise RuntimeError(
+                "SYS_ADMIN capability is required to modify GPU power limits. See "
+                "https://ml.energy/zeus/getting_started/#system-privileges "
+                "for more information or disable CPU measurement by passing cpu_indices=None to "
+                "ZeusMonitor"
+            ) from err
 
         # Resolve GPU indices. If the user did not specify `gpu_indices`, use all available GPUs.
         self.gpu_indices = (

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -188,12 +188,13 @@ class ZeusMonitor:
         except ZeusCPUInitError:
             self.cpus = EmptyCPUs()
         except ZeusRAPLPermissionError as err:
-            raise RuntimeError(
-                "SYS_ADMIN capability is required to modify GPU power limits. See "
-                "https://ml.energy/zeus/getting_started/#system-privileges "
-                "for more information or disable CPU measurement by passing cpu_indices=None to "
-                "ZeusMonitor"
-            ) from err
+            if cpu_indices:
+                raise RuntimeError(
+                    "SYS_ADMIN capability is required to read RAPL files. See "
+                    "https://ml.energy/zeus/getting_started/#system-privileges "
+                    "for more information or disable CPU measurement by passing cpu_indices=[] to "
+                    "ZeusMonitor"
+                ) from err
 
         # Resolve GPU indices. If the user did not specify `gpu_indices`, use all available GPUs.
         self.gpu_indices = (


### PR DESCRIPTION
When running the program in a docker container, `/sys/class/powercap/intel-rapl` has to be mounted on to a different path such as `zeus_sys/class/powercap/intel-rapl`. Changed RAPLCPUs so that it tries to read from `RAPL_DIR` initially and falls back to `CONTAINER_RAPL_DIR` if `RAPL_DIR` is not available. 