### PR TITLE
Feat: `python -m zeus.show_env`

### DIFF
--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -273,7 +273,7 @@ class RAPLCPUs(cpu_common.CPUs):
         self._init_cpus()
 
     @property
-    def cpus(self) -> Sequence[cpu_common.CPU]:
+    def cpus(self) -> Sequence[RAPLCPU]:
         """Returns a list of CPU objects being tracked."""
         return self._cpus
 

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -292,7 +292,7 @@ class AMDGPUs(gpu_common.GPUs):
             raise exception_class(e.msg) from e
 
     @property
-    def gpus(self) -> Sequence[gpu_common.GPU]:
+    def gpus(self) -> Sequence[AMDGPU]:
         """Return a list of AMDGPU objects being tracked."""
         return self._gpus
 

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -361,7 +361,7 @@ class NVIDIAGPUs(gpu_common.GPUs):
             ) from e
 
     @property
-    def gpus(self) -> Sequence[gpu_common.GPU]:
+    def gpus(self) -> Sequence[NVIDIAGPU]:
         """Return a list of NVIDIAGPU objects being tracked."""
         return self._gpus
 

--- a/zeus/show_env.py
+++ b/zeus/show_env.py
@@ -1,0 +1,77 @@
+"""Collect information about the environment and display it.
+
+- Python version
+- Package availablility and versions: Zeus, PyTorch, JAX.
+- NVIDIA GPU availability: Number of GPUs and moels.
+- AMD GPU availability: Number of GPUs and models.
+- Intel RAPL availability: Number of CPUs and whether DRAM measurements are available.
+"""
+
+from __future__ import annotations
+
+import platform
+
+import zeus
+from zeus.utils import framework
+from zeus.device import get_gpus, get_cpus
+from zeus.device.cpu import RAPLCPUs
+
+
+SECTION_SEPARATOR = "=" * 80 + "\n"
+
+
+def show_env():
+    """Collect information about the environment and display it."""
+    print(SECTION_SEPARATOR)
+    print(f"Python version: {platform.python_version()}\n")
+
+    print(SECTION_SEPARATOR)
+    package_availability = "\nPackage availability and versions:\n"
+    package_availability += f"  Zeus: {zeus.__version__}\n"
+
+    if framework.torch_is_available():
+        torch = framework.MODULE_CACHE["torch"]
+        package_availability += f"  PyTorch: {torch.__version__}\n"
+    else:
+        package_availability += "  PyTorch: not available\n"
+
+    if framework.jax_is_available():
+        jax = framework.MODULE_CACHE["jax"]
+        package_availability += f"  JAX: {jax.__version__}\n"
+    else:
+        package_availability += "  JAX: not available\n"
+
+    print(package_availability)
+
+    print(SECTION_SEPARATOR)
+    gpu_availability = "\nGPU availability:\n"
+    gpus = get_gpus()
+    if len(gpus) > 0:
+        for i in range(len(gpus)):
+            gpu_availability += f"  GPU {i}: {gpus.getName(i)}\n"
+    else:
+        gpu_availability += "  No GPUs available.\n"
+    print(gpu_availability)
+
+    print(SECTION_SEPARATOR)
+    cpu_availability = "\nCPU availability:\n"
+    cpus = get_cpus()
+    assert isinstance(cpus, RAPLCPUs)
+    if len(cpus) > 0:
+        for i in range(len(cpus)):
+            cpu_availability += f"  CPU {i}:\n    CPU measurements available ({cpus.cpus[i].rapl_file.path})\n"
+            if cpus.supportsGetDramEnergyConsumption(i):
+                dram = cpus.cpus[i].dram
+                assert dram is not None
+                cpu_availability += f"    DRAM measurements available ({dram.path})\n"
+            else:
+                cpu_availability += "    DRAM measurements unavailable\n"
+    else:
+        cpu_availability += "  No CPUs available.\n"
+    print(cpu_availability)
+
+    print(SECTION_SEPARATOR)
+
+
+if __name__ == "__main__":
+    show_env()

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -13,14 +13,13 @@ MODULE_CACHE: dict[str, types.ModuleType] = {}
 
 
 @lru_cache(maxsize=1)
-def torch_is_available(ensure_available: bool = False):
+def torch_is_available(ensure_available: bool = False, ensure_cuda: bool = True):
     """Check if PyTorch is available."""
     try:
         import torch
 
-        assert (
-            torch.cuda.is_available()
-        ), "PyTorch is available but does not have CUDA support."
+        if ensure_cuda and not torch.cuda.is_available():
+            raise RuntimeError("PyTorch is available but does not have CUDA support.")
         MODULE_CACHE["torch"] = torch
         logger.info("PyTorch with CUDA support is available.")
         return True
@@ -32,12 +31,13 @@ def torch_is_available(ensure_available: bool = False):
 
 
 @lru_cache(maxsize=1)
-def jax_is_available(ensure_available: bool = False):
+def jax_is_available(ensure_available: bool = False, ensure_cuda: bool = True):
     """Check if JAX is available."""
     try:
         import jax  # type: ignore
 
-        assert jax.devices("gpu"), "JAX is available but does not have CUDA support."
+        if ensure_cuda and not jax.devices("gpu"):
+            raise RuntimeError("JAX is available but does not have CUDA support.")
         MODULE_CACHE["jax"] = jax
         logger.info("JAX with CUDA support is available.")
         return True

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -18,10 +18,14 @@ def torch_is_available(ensure_available: bool = False, ensure_cuda: bool = True)
     try:
         import torch
 
-        if ensure_cuda and not torch.cuda.is_available():
+        cuda_available = torch.cuda.is_available()
+        if ensure_cuda and not cuda_available:
             raise RuntimeError("PyTorch is available but does not have CUDA support.")
         MODULE_CACHE["torch"] = torch
-        logger.info("PyTorch with CUDA support is available.")
+        logger.info(
+            "PyTorch %s CUDA support is available.",
+            "with" if cuda_available else "without",
+        )
         return True
     except ImportError as e:
         logger.info("PyTorch is not available.")
@@ -36,10 +40,13 @@ def jax_is_available(ensure_available: bool = False, ensure_cuda: bool = True):
     try:
         import jax  # type: ignore
 
-        if ensure_cuda and not jax.devices("gpu"):
+        cuda_available = jax.devices("gpu")
+        if ensure_cuda and not cuda_available:
             raise RuntimeError("JAX is available but does not have CUDA support.")
         MODULE_CACHE["jax"] = jax
-        logger.info("JAX with CUDA support is available.")
+        logger.info(
+            "JAX %s CUDA support is available.", "with" if cuda_available else "without"
+        )
         return True
     except ImportError as e:
         logger.info("JAX is not available")


### PR DESCRIPTION
This adds an in-tree script `show_env.py`.

Users can run

```console
$ python -m zeus.show_env
```

after installing Zeus with pip to understand whether Python packages and hardware (NVIDIA GPU, AMD GPU, Intel RAPL-supported CPU) are recognized.