### PR TITLE
Feat: `getAverageMemoryPowerUsage`

### DIFF
--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -234,6 +234,13 @@ class AMDGPU(gpu_common.GPU):
         )
 
     @_handle_amdsmi_errors
+    def getAverageMemoryPowerUsage(self) -> int:
+        """Return the average power usage of the GPU's memory. Units: mW."""
+        raise gpu_common.ZeusGPUNotSupportedError(
+            "Average memory power usage is not supported on AMD GPUs."
+        )
+
+    @_handle_amdsmi_errors
     def supportsGetTotalEnergyConsumption(self) -> bool:
         """Check if the GPU supports retrieving total energy consumption."""
         if self._supportsGetTotalEnergyConsumption is None:

--- a/zeus/device/gpu/common.py
+++ b/zeus/device/gpu/common.py
@@ -102,6 +102,11 @@ class GPU(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def getAverageMemoryPowerUsage(self) -> int:
+        """Return the average power usage of the GPU's memory. Units: mW."""
+        pass
+
+    @abc.abstractmethod
     def supportsGetTotalEnergyConsumption(self) -> bool:
         """Check if the GPU supports retrieving total energy consumption."""
         pass

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import functools
 import os
+import warnings
+import functools
 import contextlib
 from pathlib import Path
 from typing import Sequence
@@ -214,7 +215,13 @@ class NVIDIAGPU(gpu_common.GPU):
         )[0]
         if (ret := metric.nvmlReturn) != pynvml.NVML_SUCCESS:
             raise pynvml.NVMLError(ret)
-        return metric.value.uiVal
+        power = metric.value.uiVal
+        if power == 0:
+            warnings.warn(
+                "Average memory power returned 0. The current GPU may not be supported.",
+                stacklevel=1,
+            )
+        return power
 
     @_handle_nvml_errors
     def supportsGetTotalEnergyConsumption(self) -> bool:

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -196,7 +196,25 @@ class NVIDIAGPU(gpu_common.GPU):
         )[0]
         if (ret := metric.nvmlReturn) != pynvml.NVML_SUCCESS:
             raise pynvml.NVMLError(ret)
-        return metric.value.siVal
+        return metric.value.uiVal
+
+    @_handle_nvml_errors
+    def getAverageMemoryPowerUsage(self) -> int:
+        """Return the average power draw of the GPU's memory. Units: mW.
+
+        !!! Warning
+            This isn't exactly documented in NVML at the time of writing, but `nvidia-smi`
+            makes use of this API.
+
+            Confirmed working on H100 80GB HBM3. Confirmed not working on A40.
+        """
+        metric = pynvml.nvmlDeviceGetFieldValues(
+            self.handle,
+            [(pynvml.NVML_FI_DEV_POWER_AVERAGE, pynvml.NVML_POWER_SCOPE_MEMORY)],
+        )[0]
+        if (ret := metric.nvmlReturn) != pynvml.NVML_SUCCESS:
+            raise pynvml.NVMLError(ret)
+        return metric.value.uiVal
 
     @_handle_nvml_errors
     def supportsGetTotalEnergyConsumption(self) -> bool:


### PR DESCRIPTION
I discovered that on H100, `nvidia-smi` reports the GPU memory's power readings. This API isn't exactly documented in NVML yet and this doesn't even work on A40, but nonetheless I think it's a useful addition.