### PR TITLE
[Feat] `amdsmi` bindings integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,8 @@ dependencies = [
     "pydantic",  # The `zeus.utils.pydantic_v1` compatibility layer allows us to unpin Pydantic in most cases.
     "rich",
     "tyro",
-    "httpx"
+    "httpx",
+    "amdsmi"
 ]
 dynamic = ["version"]
 

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -251,9 +251,7 @@ class AMDGPU(gpu_common.GPU):
         )
 
     @_handle_amdsmi_errors
-    def supportsGetTotalEnergyConsumption(
-        self,
-    ) -> bool:
+    def supportsGetTotalEnergyConsumption(self) -> bool:
         """Check if the GPU supports retrieving total energy consumption. Returns a future object of the result."""
         wait_time = 0.5  # seconds
         threshold = 0.8  # 80% threshold
@@ -285,7 +283,7 @@ class AMDGPU(gpu_common.GPU):
     def getTotalEnergyConsumption(self) -> int:
         """Return the total energy consumption of the GPU since driver load. Units: mJ."""
         energy_dict = amdsmi.amdsmi_get_energy_count(self.handle)
-        if "energy_accumulator" in energy_dict:  # New API
+        if "energy_accumulator" in energy_dict:  # Changed since amdsmi 6.2.1
             energy = (
                 energy_dict["energy_accumulator"] * energy_dict["counter_resolution"]
             )

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -278,8 +278,8 @@ class AMDGPU(gpu_common.GPU):
         else:
             self._supportsGetTotalEnergyConsumption = False
             logger.info(
-                "Disabling `getTotalEnergyConsumption` for device %d. The result of `amdsmi.amdsmi_get_energy_count` is not accurate. Expected energy: %d mJ, Measured energy: %d mJ"
-                "This is a known issue with some AMD GPUs, please see https://github.com/ROCm/amdsmi/issues/38 for more information."
+                "Disabling `getTotalEnergyConsumption` for device %d. The result of `amdsmi.amdsmi_get_energy_count` is not accurate. Expected energy: %d mJ, Measured energy: %d mJ. "
+                "This is a known issue with some AMD GPUs, please see https://github.com/ROCm/amdsmi/issues/38 for more information. "
                 "Energy metrics will still be available and measured through polling of `getInstantPowerUsage` method.",
                 self.gpu_index,
                 expected_energy,

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -51,7 +51,10 @@ def amdsmi_is_available() -> bool:
         return False
     # usually thrown if versions of amdsmi and ROCm are incompatible.
     except AttributeError:
-        logger.warning("Do you have the correct version of ROCm and amdsmi installed?")
+        logger.warning(
+            "Failed to import amdsmi. "
+            "Ensure amdsmi's version is at least as high as the current ROCm version."
+        )
         return False
     try:
         amdsmi.amdsmi_init()

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -256,7 +256,7 @@ class AMDGPU(gpu_common.GPU):
     ) -> bool:
         """Check if the GPU supports retrieving total energy consumption. Returns a future object of the result."""
         wait_time = 0.5  # seconds
-        threshold = 0.01  # 1% threshold
+        threshold = 0.8  # 80% threshold
 
         power = self.getInstantPowerUsage()
         initial_energy = self.getTotalEnergyConsumption()

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -85,9 +85,8 @@ class AMDGPU(gpu_common.GPU):
         super().__init__(gpu_index)
         self._get_handle()
 
-        self._supportsGetTotalEnergyConsumption = (
-            None  # Must be set by `supportsGetTotalEnergyConsumption`
-        )
+        # Must be set by `supportsGetTotalEnergyConsumption`
+        self._supportsGetTotalEnergyConsumption = None
 
     _exception_map = {
         1: gpu_common.ZeusGPUInvalidArgError,  # amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL
@@ -273,7 +272,7 @@ class AMDGPU(gpu_common.GPU):
         expected_energy = power * wait_time  # power is in mW, wait_time is in seconds
 
         # if the difference between measured and expected energy is less than 1% of the expected energy, then the API is supported
-        if abs(measured_energy - expected_energy) < threshold * expected_energy:
+        if 0.1 < measured_energy / expected_energy < 10:
             self._supportsGetTotalEnergyConsumption = True
         else:
             self._supportsGetTotalEnergyConsumption = False

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -85,7 +85,9 @@ class AMDGPU(gpu_common.GPU):
         super().__init__(gpu_index)
         self._get_handle()
 
-        self._supportsGetTotalEnergyConsumption = None # Must be set by `supportsGetTotalEnergyConsumption`
+        self._supportsGetTotalEnergyConsumption = (
+            None  # Must be set by `supportsGetTotalEnergyConsumption`
+        )
 
     _exception_map = {
         1: gpu_common.ZeusGPUInvalidArgError,  # amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL
@@ -255,7 +257,6 @@ class AMDGPU(gpu_common.GPU):
     @_handle_amdsmi_errors
     def supportsGetTotalEnergyConsumption(self) -> bool:
         """Check if the GPU supports retrieving total energy consumption. Returns a future object of the result."""
-
         # Return cached value if available
         if self._supportsGetTotalEnergyConsumption is not None:
             return self._supportsGetTotalEnergyConsumption

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -261,7 +261,7 @@ class AMDGPU(gpu_common.GPU):
             return self._supportsGetTotalEnergyConsumption
 
         wait_time = 0.5  # seconds
-        threshold = 0.8  # 80% threshold
+        threshold = 0.1  # 10% threshold
 
         power = self.getInstantPowerUsage()
         initial_energy = self.getTotalEnergyConsumption()

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -244,7 +244,7 @@ class AMDGPU(gpu_common.GPU):
     def getAveragePowerUsage(self) -> int:
         """Return the average power draw of the GPU. Units: mW."""
         # returns in W, convert to mW
-        return int(
+        return (
             int(amdsmi.amdsmi_get_power_info(self.handle)["average_socket_power"])
             * 1000
         )

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -85,6 +85,8 @@ class AMDGPU(gpu_common.GPU):
         super().__init__(gpu_index)
         self._get_handle()
 
+        self._supportsGetTotalEnergyConsumption = None # Must be set by `supportsGetTotalEnergyConsumption`
+
     _exception_map = {
         1: gpu_common.ZeusGPUInvalidArgError,  # amdsmi.amdsmi_wrapper.AMDSMI_STATUS_INVAL
         2: gpu_common.ZeusGPUNotSupportedError,  # amdsmi.amdsmi_wrapper.AMDSMI_STATUS_NOT_SUPPORTED
@@ -253,6 +255,11 @@ class AMDGPU(gpu_common.GPU):
     @_handle_amdsmi_errors
     def supportsGetTotalEnergyConsumption(self) -> bool:
         """Check if the GPU supports retrieving total energy consumption. Returns a future object of the result."""
+
+        # Return cached value if available
+        if self._supportsGetTotalEnergyConsumption is not None:
+            return self._supportsGetTotalEnergyConsumption
+
         wait_time = 0.5  # seconds
         threshold = 0.8  # 80% threshold
 

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -348,8 +348,10 @@ class AMDGPUs(gpu_common.GPUs):
 
         # set _supportsInstantPowerUsage for all GPUs
         for gpu in self._gpus:
-            if gpu.getInstantPowerUsage() == "N/A":
-                gpu._supportsInstantPowerUsage = False
+            gpu._supportsInstantPowerUsage = isinstance(
+                amdsmi.amdsmi_get_power_info(gpu.handle)["current_socket_power"],
+                int,
+            )
 
         # set _supportsGetTotalEnergyConsumption for all GPUs
         wait_time = 0.5  # seconds

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -254,7 +254,9 @@ class AMDGPU(gpu_common.GPU):
         """Return the current power draw of the GPU. Units: mW."""
         if self._supportsInstantPowerUsage is False:
             raise gpu_common.ZeusGPUNotSupportedError(
-                "Instant power usage is not supported on this AMD GPU."
+                "Instant power usage is not supported on this AMD GPU. "
+                "This is because amdsmi.amdsmi_get_power_info does not return a valid 'current_socket_power'. "
+                "Please use `getAveragePowerUsage` instead."
             )
         # returns in W, convert to mW
         return int(
@@ -377,7 +379,7 @@ class AMDGPUs(gpu_common.GPUs):
                 logger.info(
                     "Disabling `getTotalEnergyConsumption` for device %d. The result of `amdsmi.amdsmi_get_energy_count` is not accurate. Expected energy: %d mJ, Measured energy: %d mJ. "
                     "This is a known issue with some AMD GPUs, please see https://github.com/ROCm/amdsmi/issues/38 for more information. "
-                    "Energy metrics will still be available and measured through polling of `getInstantPowerUsage` method.",
+                    "Energy metrics will still be available and measured through polling of either `getInstantPowerUsage` or `getAveragePowerUsage` method.",
                     gpu.gpu_index,
                     expected_energy,
                     measured_energy,

--- a/zeus/device/gpu/common.py
+++ b/zeus/device/gpu/common.py
@@ -97,6 +97,11 @@ class GPU(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def getAveragePowerUsage(self) -> int:
+        """Return the average power usage of the GPU. Units: mW."""
+        pass
+
+    @abc.abstractmethod
     def getInstantPowerUsage(self) -> int:
         """Return the current power draw of the GPU. Units: mW."""
         pass

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -190,6 +190,16 @@ class NVIDIAGPU(gpu_common.GPU):
         pynvml.nvmlDeviceResetGpuLockedClocks(self.handle)
 
     @_handle_nvml_errors
+    def getAveragePowerUsage(self) -> int:
+        """Return the current power draw of the GPU. Units: mW."""
+        metric = pynvml.nvmlDeviceGetFieldValues(
+            self.handle, [pynvml.NVML_FI_DEV_POWER_AVERAGE]
+        )[0]
+        if (ret := metric.nvmlReturn) != pynvml.NVML_SUCCESS:
+            raise pynvml.NVMLError(ret)
+        return metric.value.uiVal
+
+    @_handle_nvml_errors
     def getInstantPowerUsage(self) -> int:
         """Return the current power draw of the GPU. Units: mW."""
         metric = pynvml.nvmlDeviceGetFieldValues(

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -191,7 +191,7 @@ class NVIDIAGPU(gpu_common.GPU):
 
     @_handle_nvml_errors
     def getAveragePowerUsage(self) -> int:
-        """Return the current power draw of the GPU. Units: mW."""
+        """Return the average power draw of the GPU. Units: mW."""
         metric = pynvml.nvmlDeviceGetFieldValues(
             self.handle, [pynvml.NVML_FI_DEV_POWER_AVERAGE]
         )[0]


### PR DESCRIPTION
- Added amdsmi to project dependency
- Implemented a non-blocking contructor of AMDGPU using concurrent.futures.ThreadPoolExecutor (AMDGPUs constructor takes 0.5s (polling time) regardless of number of GPUs)
- Right now, it succeeds if the measured value is in 1% of expected value, and waits 0.5s. These can be changed.

A few questions:
1. What do you think about the threshold (1%) and wait time (0.5s)?
2. This is failing pyright check:
`zeus/zeus/device/gpu/amd.py:247:13 - error: Operator "*" not supported for types "c_uint32" and "Literal[1000]" (reportOperatorIssue)
  zeus/zeus/device/gpu/amd.py:258:9 - error: Method "supportsGetTotalEnergyConsumption" overrides class "GPU" in an incompatible manner
    Positional parameter count mismatch; base method has 1, but override has 2 (reportIncompatibleMethodOverride)
  zeus/zeus/device/gpu/amd.py:280:26 - error: Cannot assign to attribute "_supportsGetTotalEnergyConsumption" for class "AMDGPU*"
    Attribute "_supportsGetTotalEnergyConsumption" is unknown (reportAttributeAccessIssue)
  zeus/zeus/device/gpu/amd.py:282:26 - error: Cannot assign to attribute "_supportsGetTotalEnergyConsumption" for class "AMDGPU*"
    Attribute "_supportsGetTotalEnergyConsumption" is unknown (reportAttributeAccessIssue)
  zeus/zeus/device/gpu/amd.py:293:26 - error: Cannot assign to attribute "_supportsGetTotalEnergyConsumption" for class "AMDGPU*"
    Attribute "_supportsGetTotalEnergyConsumption" is unknown (reportAttributeAccessIssue)
  zeus/zeus/device/gpu/amd.py:344:19 - error: Cannot access attribute "value" for class "AmdSmiException"
    Attribute "value" is unknown (reportAttributeAccessIssue)
  zeus/zeus/device/gpu/amd.py:346:37 - error: Cannot access attribute "msg" for class "AmdSmiException"`
  I can fix these, but do you think this is the right approach? I wanted to make sure before tweaking base class signatures.
  