### PR TITLE
Make sure to assign EmptyCPUs to cpus if there is a permission error

### DIFF
--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -194,6 +194,7 @@ class ZeusMonitor:
                     "for more information or disable CPU measurement by passing cpu_indices=[] to "
                     "ZeusMonitor"
                 ) from err
+            self.cpus = EmptyCPUs()
 
         # Resolve GPU indices. If the user did not specify `gpu_indices`, use all available GPUs.
         self.gpu_indices = (


### PR DESCRIPTION
When `cpu_indices=None` for initializing `ZeusMonitor` and there is a permission error (not run with sudo), make sure to assign `self.cpus = EmptyCPUs()` 