### PR TITLE
[Fix] Fix tests failing due to deprecated `app` argument in httpx client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,12 @@ Documentation = "https://ml.energy/zeus"
 [project.optional-dependencies]
 # One day FastAPI will drop support for Pydantic V1. Then fastapi has to be pinned as well.
 pfo = ["pydantic<2"]
-pfo-server = ["fastapi[all]", "pydantic<2", "lowtime", "aiofiles", "torch"]
+pfo-server = ["fastapi[standard]", "pydantic<2", "lowtime", "aiofiles", "torch"]
 bso = ["pydantic<2"]
-bso-server = ["fastapi[all]", "sqlalchemy", "pydantic<2", "python-dotenv"]
+bso-server = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "python-dotenv"]
 migration = ["alembic", "sqlalchemy", "pydantic<2", "python-dotenv"]
 lint = ["ruff", "black==22.6.0", "pyright", "pandas-stubs", "transformers"]
-test = ["fastapi[all]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
+test = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
 docs = ["mkdocs-material[imaging]==9.5.19", "mkdocstrings[python]==0.25.0", "mkdocs-gen-files==0.5.0", "mkdocs-literate-nav==0.6.1", "mkdocs-section-index==0.3.9", "mkdocs-redirects==1.2.1", "urllib3<2", "black"]
 # greenlet is for supporting apple mac silicon for sqlalchemy(https://docs.sqlalchemy.org/en/20/faq/installation.html)
 dev = ["zeus-ml[pfo-server,bso,bso-server,migration,lint,test]", "greenlet"]

--- a/zeus/optimizer/pipeline_frequency/server/router.py
+++ b/zeus/optimizer/pipeline_frequency/server/router.py
@@ -44,7 +44,7 @@ class LoggingRoute(APIRoute):
                 request.method,
                 request.url,
                 await request.json() if await request.body() else "None",
-                response.body.decode(response.charset),
+                bytes(response.body).decode(response.charset),
             )
             return response
 


### PR DESCRIPTION
- Use narrower `fastapi[standard]`, instead of `fastapi[all]`. Checked the dependencies that will be removed and I think it should be fine.
- Fixed a small typing error.