### PR TITLE
Out of Bounds Power Limit in `GlobalPowerLimitOptimizer`

### DIFF
--- a/zeus/optimizer/power_limit.py
+++ b/zeus/optimizer/power_limit.py
@@ -263,9 +263,7 @@ class GlobalPowerLimitOptimizer(Callback):
             pls.append(gpus.getPowerManagementLimitConstraints(index))
         if not all(pls[0] == pl for pl in pls):
             raise ValueError("Power limits ranges are not uniform across GPUs.")
-        self.power_limits = list(
-            range(pls[0][1], pls[0][0] - self.pl_step, -self.pl_step)
-        )
+        self.power_limits = list(range(pls[0][1], pls[0][0] - 1, -self.pl_step))
 
         # Turn on persistence mode and set to the highest power limit.
         try:


### PR DESCRIPTION
When testing on an NVIDIA Quadro RTX 6000 with a powerlimit range of 100 - 260W, `GlobalPowerLimitOptimizer` incorrectly includes 85W with the default pl_step of 25, which results in an error when trying to test this power limit. This fix ensures the lower bound of the power limits is always valid.