### PR TITLE
[CI] Upgrade `actions/cache` to V4

### DIFF
--- a/.github/workflows/check_homepage_build.yaml
+++ b/.github/workflows/check_homepage_build.yaml
@@ -28,7 +28,7 @@ jobs:
           python-version: 3.9
           cache: 'pip'
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/deploy_homepage.yaml
+++ b/.github/workflows/deploy_homepage.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: 3.9
           cache: 'pip'
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/zeusd_fmt_lint_test.yaml
+++ b/.github/workflows/zeusd_fmt_lint_test.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install the Rust toolchain
         run: rustup toolchain install stable --profile minimal
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
`actions/cache` V1 and V2 are scheduled for deprecation and removal. Attempting to upgrade to the latest V4.