### PR TITLE
[Misc] Redirect stdout to `None` on `import amdsmi`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ bso = ["pydantic<2"]
 bso-server = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "python-dotenv"]
 migration = ["alembic", "sqlalchemy", "pydantic<2", "python-dotenv"]
 prometheus = ["prometheus-client"]
-lint = ["ruff", "black==22.6.0", "pyright", "pandas-stubs", "transformers"]
+lint = ["ruff", "black==22.6.0", "pyright!=1.1.395", "pandas-stubs", "transformers"]
 test = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
 docs = ["mkdocs-material[imaging]==9.5.19", "mkdocstrings[python]==0.25.0", "mkdocs-gen-files==0.5.0", "mkdocs-literate-nav==0.6.1", "mkdocs-section-index==0.3.9", "mkdocs-redirects==1.2.1", "urllib3<2", "black"]
 # greenlet is for supporting apple mac silicon for sqlalchemy(https://docs.sqlalchemy.org/en/20/faq/installation.html)

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -9,7 +9,9 @@ from typing import Sequence
 from functools import lru_cache
 
 try:
-    import amdsmi  # type: ignore
+    # `amdsmi` prints to stdout on import when libamd_smi.so is not found.
+    with contextlib.redirect_stdout(None):
+        import amdsmi  # type: ignore
 # must catch all exceptions, since ImportError is not the only exception that can be raised (ex. OSError on version mismatch).
 # Specific exceptions are handled when import and initialization are retested in `amdsmi_is_available`
 except Exception:


### PR DESCRIPTION
`amdsmi` prints to stdout (with `print`) when the `libamd_smi.so` shared library could not be found. We don't want users to be bothered by this.