### PR TITLE
SoC Device Abstraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ pydocstyle.convention = "google"
 "zeus/optimizer/batch_size/common.py" = ["N805"]
 "zeus/device/gpu/*.py" = ["N802", "N803"]
 "zeus/device/cpu/*.py" = ["N802"]
+"zeus/device/soc/*.py" = ["N802"]
 "zeus/utils/testing.py" = ["N802"]
 
 [tool.pytest.ini_options]

--- a/zeus/device/__init__.py
+++ b/zeus/device/__init__.py
@@ -2,3 +2,4 @@
 
 from zeus.device.gpu import get_gpus
 from zeus.device.cpu import get_cpus
+from zeus.device.soc import get_soc

--- a/zeus/device/exception.py
+++ b/zeus/device/exception.py
@@ -19,6 +19,14 @@ class ZeusBaseCPUError(ZeusBaseError):
         super().__init__(message)
 
 
+class ZeusBaseSoCError(ZeusBaseError):
+    """Zeus base SoC exception class."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Base Zeus Exception."""
+        super().__init__(message)
+
+
 class ZeusdError(ZeusBaseGPUError):
     """Exception class for Zeus daemon-related errors."""
 

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -1,0 +1,31 @@
+"""Abstraction layer for SoC devices.
+
+The main function of this module is [`get_soc`][zeus.device.soc.get_soc],
+which returns a SoC Manager object specific to the platform.
+"""
+
+from __future__ import annotations
+
+from zeus.device.soc.common import SoC, ZeusSoCInitError
+
+_soc: SoC | None = None
+
+def get_soc() -> SoC:
+    """Initialize and return a singleton monolithic SoC monitoring object.
+
+    The function returns a SoC management object that aims to abstract underlying SoC monitoring
+    functionalities.
+
+    Currently, no SoC management object has been implemented for any SoC architecture, and calling 
+    this function will raise a `ZeusSoCInitError` error if called; implementations for SoC devices
+    are expected to be added in the near future.
+    """
+    global _soc
+    if _soc is not None:
+        return _soc
+
+    # SoCs in the future can be incorporated via `elif` blocks.
+    else:
+        raise ZeusSoCInitError(
+            "No observable SoC was found on the current machine."
+        )

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -10,13 +10,14 @@ from zeus.device.soc.common import SoC, ZeusSoCInitError
 
 _soc: SoC | None = None
 
+
 def get_soc() -> SoC:
     """Initialize and return a singleton monolithic SoC monitoring object.
 
     The function returns a SoC management object that aims to abstract underlying SoC monitoring
     functionalities.
 
-    Currently, no SoC management object has been implemented for any SoC architecture, and calling 
+    Currently, no SoC management object has been implemented for any SoC architecture, and calling
     this function will raise a `ZeusSoCInitError` error if called; implementations for SoC devices
     are expected to be added in the near future.
     """
@@ -26,6 +27,7 @@ def get_soc() -> SoC:
 
     # SoCs in the future can be incorporated via `elif` blocks.
     else:
-        raise ZeusSoCInitError(
-            "No observable SoC was found on the current machine."
-        )
+        # Placeholder to avoid linting error (remove once _soc can be assigned a real value).
+        _soc = None
+
+        raise ZeusSoCInitError("No observable SoC was found on the current machine.")

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -17,9 +17,9 @@ def get_soc() -> SoC:
     The function returns a SoC management object that aims to abstract underlying SoC monitoring
     functionalities.
 
-    Currently, no SoC management object has been implemented for any SoC architecture, and calling
-    this function will raise a `ZeusSoCInitError` error if called; implementations for SoC devices
-    are expected to be added in the near future.
+    Currently, no management object has been implemented for any SoC architecture, so calling this
+    function will raise a `ZeusSoCInitError` error; implementations for SoC devices are expected
+    to be added in the near future.
     """
     global _soc
     if _soc is not None:

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -32,12 +32,12 @@ class SoCMeasurement(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         """Show all fields and their observed values in the measurement object."""
         pass
 
     @abc.abstractmethod
-    def __sub__(self, other):
+    def __sub__(self, other) -> SoCMeasurement:
         """Produce a single measurement object containing the difference across all fields."""
         pass
 

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -1,0 +1,64 @@
+"""Error wrappers and classes common to all SoC devices."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+
+from zeus.device.exception import ZeusBaseSoCError
+
+
+class ZeusSoCInitError(ZeusBaseSoCError):
+    """Import error for SoC initialization failures."""
+
+    def __init__(self, message: str) -> None:
+        """Intialize the exception object."""
+        super().__init__(message)
+
+
+@dataclass
+class SoCMeasurement(abc.ABC):
+    """Represents energy consumption metrics of various subsystems on a SoC processor.
+
+    Since subsystems available on a SoC processor are highly variable, the fields of
+    this dataclass are entirely up to each derived class.
+
+    Fields available and implemented for a specific SoC processor architecture can be
+    found by referring to the SoCMeasurement derived class corresponding to that
+    particular architecture (e.g., `AppleSiliconMeasurement` for Apple silicon),
+    or by simply printing an instance of that derived class.
+    """
+    
+    @abc.abstractmethod
+    def __str__(self):
+        """Show all fields and their observed values in the measurement object."""
+        pass
+
+
+class SoC(abc.ABC):
+    """An abstract base class for monitoring the energy consumption of a monolithic SoC processor.
+    
+    This class will be utilized by ZeusMonitor.
+    """
+
+    @abc.abstractmethod
+    def __init__(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def getAvailableMetrics(self) -> Set[str]:
+        """Return a set of all observable metrics on the current processor."""
+        pass
+
+    @abc.abstractmethod
+    def getTotalEnergyConsumption(self, index: int) -> SoCMeasurement:
+        """Returns the total energy consumption of the SoC. Units: mJ."""
+    
+    def beginWindow(self, key) -> None:
+        """Begin a measurement interval labeled with `key`."""
+        pass
+    
+    def endWindow(self, key) -> SoCMeasurement:
+        """End the measurement interval labeled with `key` and return the energy
+        consumed by processor subsystems during the interval. Units: mJ."""
+        pass

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -61,9 +61,9 @@ class SoC(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def supportsEnergyMonitoring(self) -> bool:
-        """Return if energy monitoring is supported. This should be true for all derived class
-        implementations of SoC except `EmptySoC`.
+    def isPresent(self) -> bool:
+        """Return if an SoC is present on the current device. This should be true for all derived
+        class implementations of the SoC manager except `EmptySoC`.
         """
         pass
 
@@ -106,9 +106,9 @@ class EmptySoC(SoC):
         """Return an empty set, as no metrics are observable if no SoC is detected."""
         return set()
 
-    def supportsEnergyMonitoring(self) -> bool:
-        """Return if energy monitoring is supported. This should be true for all derived class
-        implementations of SoC except `EmptySoC`.
+    def isPresent(self) -> bool:
+        """Return if an SoC is present on the current device. This should be true for all derived
+        class implementations of the SoC manager except `EmptySoC`.
         """
         return False
 

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -41,6 +41,11 @@ class SoCMeasurement(abc.ABC):
         """Produce a single measurement object containing differences across all fields."""
         pass
 
+    @abc.abstractmethod
+    def zeroAllFields(self) -> None:
+        """Set the value of all fields in the measurement object to zero."""
+        pass
+
 
 class SoC(abc.ABC):
     """An abstract base class for monitoring the energy consumption of a monolithic SoC processor.

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -38,7 +38,7 @@ class SoCMeasurement(abc.ABC):
 
     @abc.abstractmethod
     def __sub__(self, other) -> SoCMeasurement:
-        """Produce a single measurement object containing the difference across all fields."""
+        """Produce a single measurement object containing differences across all fields."""
         pass
 
 
@@ -66,7 +66,7 @@ class SoC(abc.ABC):
     def isPresent(self) -> bool:
         """Return if an SoC is present on the current device.
 
-        This should be true for all derived classes of the SoC manager except `EmptySoC`.
+        This should be true for all derived classes of the `SoC` manager except `EmptySoC`.
         """
         pass
 
@@ -74,8 +74,9 @@ class SoC(abc.ABC):
     def getTotalEnergyConsumption(self) -> SoCMeasurement:
         """Returns the total energy consumption of the SoC.
 
-        The measurement should be cumulative, with different calls to this function all
-        counting from a fixed arbitrary point in time.
+        The measurement should be cumulative; different calls to this function throughout
+        the lifetime of a single `SoC` manager object should count from a fixed arbitrary
+        point in time.
 
         Units: mJ.
         """
@@ -92,12 +93,12 @@ class SoC(abc.ABC):
         """End a measurement window and return the energy consumption. Units: mJ."""
         # Retrieve the measurement taken at the start of the window.
         try:
-            start_measurement: SoCMeasurement = self.measurement_states.pop(key)
+            start_cumulative: SoCMeasurement = self.measurement_states.pop(key)
         except KeyError:
             raise KeyError(f"Measurement window '{key}' does not exist") from None
 
-        end_measurement: SoCMeasurement = self.getTotalEnergyConsumption()
-        return end_measurement - start_measurement
+        end_cumulative: SoCMeasurement = self.getTotalEnergyConsumption()
+        return end_cumulative - start_cumulative
 
 
 class EmptySoC(SoC):
@@ -108,7 +109,7 @@ class EmptySoC(SoC):
         pass
 
     def getAvailableMetrics(self) -> set[str]:
-        """Return an empty set, as no metrics are observable if no SoC is detected."""
+        """Return a set of all observable metrics on the current processor."""
         return set()
 
     def isPresent(self) -> bool:

--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -61,6 +61,13 @@ class SoC(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def supportsEnergyMonitoring(self) -> bool:
+        """Return if energy monitoring is supported. This should be true for all derived class
+        implementations of SoC except `EmptySoC`.
+        """
+        pass
+
+    @abc.abstractmethod
     def getTotalEnergyConsumption(self) -> SoCMeasurement:
         """Returns the total energy consumption of the SoC, cumulative from a fixed arbitrary
         point in time. Units: mJ.
@@ -74,7 +81,6 @@ class SoC(abc.ABC):
 
         self.measurement_states[key] = self.getTotalEnergyConsumption()
 
-
     def endWindow(self, key) -> SoCMeasurement:
         """End the measurement interval labeled with `key` and return the energy
         consumed by processor subsystems during the interval. Units: mJ."""
@@ -87,3 +93,36 @@ class SoC(abc.ABC):
         
         end_measurement: SoCMeasurement = self.getTotalEnergyConsumption()
         return end_measurement - start_measurement
+
+
+class EmptySoC(SoC):
+    """Empty SoC management object to be used when SoC management object is unavailable."""
+
+    def __init__(self) -> None:
+        """Initialize an empty SoC class."""
+        pass
+
+    def getAvailableMetrics(self) -> Set[str]:
+        """Return an empty set, as no metrics are observable if no SoC is detected."""
+        return set()
+
+    def supportsEnergyMonitoring(self) -> bool:
+        """Return if energy monitoring is supported. This should be true for all derived class
+        implementations of SoC except `EmptySoC`.
+        """
+        return False
+
+    def getTotalEnergyConsumption(self) -> SoCMeasurement:
+        """Returns the total energy consumption of the SoC, cumulative from a fixed arbitrary
+        point in time. Units: mJ.
+        """
+        raise ValueError("No SoC is available.")
+
+    def beginWindow(self, key) -> None:
+        """Begin a measurement interval labeled with `key`."""
+        raise ValueError("No SoC is available.")
+
+    def endWindow(self, key) -> SoCMeasurement:
+        """End the measurement interval labeled with `key` and return the energy
+        consumed by processor subsystems during the interval. Units: mJ."""
+        raise ValueError("No SoC is available.")

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -306,7 +306,7 @@ class ZeusMonitor:
                 dram_energy_state[cpu_index] = cpu_measurement.dram_mj
 
         if self.soc.isPresent():
-            self.soc.beginWindow()
+            self.soc.beginWindow(key)
 
         # Add measurement state to dictionary.
         self.measurement_states[key] = MeasurementState(
@@ -395,7 +395,7 @@ class ZeusMonitor:
 
         soc_energy_consumption: SoCMeasurement | None = None
         if self.soc.isPresent():
-            soc_energy_consumption = self.soc.endWindow()
+            soc_energy_consumption = self.soc.endWindow(key)
 
         # If there are older GPU architectures, the PowerMonitor will take care of those.
         if self.power_monitor is not None:

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -364,7 +364,7 @@ class ZeusMonitor:
         if cancel:
             logger.debug("Measurement window '%s' cancelled.", key)
 
-            # If we had a non-None SoC measurement object to report, empty its fields. 
+            # If we had a non-None SoC measurement object to report, empty its fields.
             if soc_energy_consumption is not None:
                 soc_energy_consumption.zeroAllFields()
 

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -13,9 +13,10 @@ from functools import cached_property
 from zeus.monitor.power import PowerMonitor
 from zeus.utils.logging import get_logger
 from zeus.utils.framework import sync_execution as sync_execution_fn
-from zeus.device import get_gpus, get_cpus
+from zeus.device import get_gpus, get_cpus, get_soc
 from zeus.device.gpu.common import ZeusGPUInitError, EmptyGPUs
 from zeus.device.cpu.common import ZeusCPUInitError, ZeusCPUNoPermissionError, EmptyCPUs
+from zeus.device.soc.common import ZeusSoCInitError, SoCMeasurement, EmptySoC
 
 logger = get_logger(__name__)
 
@@ -42,6 +43,8 @@ class Measurement:
     gpu_energy: dict[int, float]
     cpu_energy: dict[int, float] | None = None
     dram_energy: dict[int, float] | None = None
+
+    soc_energy: SoCMeasurement | None = None
 
     @cached_property
     def total_energy(self) -> float:
@@ -196,6 +199,13 @@ class ZeusMonitor:
                 ) from err
             self.cpus = EmptyCPUs()
 
+        # Get an SoC instance, if an SoC is present on the host device.
+        try:
+            self.soc = get_soc()
+        except ZeusSoCInitError:
+            # No SoC was found.
+            self.soc = EmptySoC()
+
         # Resolve GPU indices. If the user did not specify `gpu_indices`, use all available GPUs.
         self.gpu_indices = (
             gpu_indices if gpu_indices is not None else list(range(len(self.gpus)))
@@ -295,6 +305,9 @@ class ZeusMonitor:
             if cpu_measurement.dram_mj is not None:
                 dram_energy_state[cpu_index] = cpu_measurement.dram_mj
 
+        if self.soc.isPresent():
+            self.soc.beginWindow()
+
         # Add measurement state to dictionary.
         self.measurement_states[key] = MeasurementState(
             time=timestamp,
@@ -348,6 +361,7 @@ class ZeusMonitor:
                 time=0.0,
                 gpu_energy={gpu: 0.0 for gpu in self.gpu_indices},
                 cpu_energy={cpu: 0.0 for cpu in self.cpu_indices},
+                soc_energy=None,
             )
 
         end_time: float = time()
@@ -378,6 +392,10 @@ class ZeusMonitor:
                 dram_energy_consumption[cpu_index] = (
                     cpu_measurement.dram_mj - dram_start_energy[cpu_index]
                 )
+
+        soc_energy_consumption: SoCMeasurement | None = None
+        if self.soc.isPresent():
+            soc_energy_consumption = self.soc.endWindow()
 
         # If there are older GPU architectures, the PowerMonitor will take care of those.
         if self.power_monitor is not None:
@@ -421,4 +439,5 @@ class ZeusMonitor:
             gpu_energy=gpu_energy_consumption,
             cpu_energy=cpu_energy_consumption or None,
             dram_energy=dram_energy_consumption or None,
+            soc_energy=soc_energy_consumption,
         )


### PR DESCRIPTION
# High level overview:

- [Related Issue](https://github.com/ml-energy/zeus/issues/159)
- Introduces a skeleton implementation of an SoC manager object, serving as a base class for device-specific interfaces to SoC architectures (e.g., Apple Silicon, NVIDIA Jetson).
- Provides a starting point for how `ZeusMonitor` should interact with and utilize the SoC manager class described above.

# New SoC Directory

This PR will add a new directory `soc` under [devices](https://github.com/ml-energy/zeus/tree/master/zeus/device). Implementations of manager objects to specific SoCs should be placed in here.

As part of this PR, two new files will be added to this `soc` directory.

## zeus/device/soc/__init__.py

This file contains an implementation of `get_soc`, which `ZeusMonitor` will call to attempt to get an instance of an SoC manager object. As new SoC devices are added to Zeus, this function should be expanded to check if a host device matches those new SoC architectures.

If no SoC is found or available on the host device, this function raises an exception. This will cause `ZeusMonitor` to initialize its `self.soc` member variable to an `EmptySoC` instance.

## zeus/device/soc/common.py

The classes defined in here provide a skeleton structure for how specific SoC managers should be implemented.

### `SoCMeasurement` class

This dataclass represents an object containing energy metrics for components available on an SoC. Since the actual subsystems available on an SoC can vary widely across specific SoC architectures, deciding what fields should be contained in this class is left to each derived class implementation of this class.

There are two abstract functions this class forces derived classes to implement:

**`__str__`**

- When ZeusMonitor reports a measurement to the end-user, it will include an instance of this `SoCMeasurement` class in the [`Measurement`](https://github.com/ml-energy/zeus/blob/24860eb513a2e71a0e80b2c08bf0df63ca098b0a/zeus/monitor/energy.py#L24) object that it returns. To make it easier for the end-user to know which fields exist, we enforce that derived classes implement `__str__` so that the user can simply pass an instance of the object into `print`.
- Alternatively, we could have ZeusMonitor just include in `Measurement` a dict with SoC metrics instead of an instance of `SoCMeasurement`, but even then, having `SoCMeasurement` be printable would be nice.

**`__sub__`**

- To calculate energy consumed over intervals, the `SoC` manager class will perform subtraction over cumulative measurements. But since it's not possible for the base SoC manager class to know what fields exist and must be subtracted on an arbitrary instance of `SoCMeasurement`, this subtraction logic is left for derived classes of `SoCMeasurement` to implement.

### `SoC` manager class

This class is meant to be a base class for interfaces to specific SoC architectures.

One important thing about this class is that it provides a default implementation for `begin_window` and `end_window` that relies on a derived class providing an implementation for `getTotalEnergyConsumption`. Unless a derived class provides an overriding implementation of `begin_window` and `end_window`, the default behavior of the SoC manager base class is to implement those two methods by subtracting cumulative measurements taken at the end and start of a window to calculate the energy consumed in between.

If a derived class intends to rely on the base class's implementation of these two methods, it must invoke the base class constructor in its own constructor. This is because the base class constructor initializes the dictionary needed to keep track of window states.

However, if a derived class wants to implement `begin_window` and `end_window` in a different way or needs additional features in those methods, it can override those methods; if it does this, it can safely skip invoking the base class's constructor.