### PR TITLE
Update `amdsmi` exception handling

### DIFF
--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -58,6 +58,13 @@ def amdsmi_is_available() -> bool:
             "Ensure amdsmi's version is at least as high as the current ROCm version."
         )
         return False
+    except KeyError as e:
+        logger.warning(
+            "Failed to import amdsmi due to a key error on: [%s]. "
+            "Ensure that amdsmi is installed on your system.",
+            e,
+        )
+        return False
     try:
         amdsmi.amdsmi_init()
         logger.info("amdsmi is available and initialized")


### PR DESCRIPTION
Trying to import `amdsmi` in [amd.py](https://github.com/ml-energy/zeus/blob/40bde9c9e57f2663ba81b19957857ecd9d23289f/zeus/device/gpu/amd.py#L45) has been causing a `Key Error` propagated up from amdsmi bindings. 

If a machine does not have `libamd_smi.so` installed, an `OSError` exception would be raised at the amdsmi bindings level, but the bindings were [catching the exception](https://github.com/ml-energy/amdsmi/blob/5aa2a4834a7fb59b4ac3bdec9853ebbed70aa2d6/py-interface/amdsmi/amdsmi_wrapper.py#L181) and moving on instead of stopping execution. As a result, a [bad dictionary access](https://github.com/ml-energy/amdsmi/blob/5aa2a4834a7fb59b4ac3bdec9853ebbed70aa2d6/py-interface/amdsmi/amdsmi_wrapper.py#L2065) would later be made in the bindings, causing an uncaught `Key Error` to happen and rise to Zeus.

Since amdsmi bindings are generated automatically, this PR introduces a fix at the Zeus level by catching the `Key Error`.