### PR TITLE
Update SoC device common

### DIFF
--- a/zeus/device/soc/common.py
+++ b/zeus/device/soc/common.py
@@ -32,11 +32,6 @@ class SoCMeasurement(abc.ABC):
     """
 
     @abc.abstractmethod
-    def __str__(self) -> str:
-        """Show all fields and their observed values in the measurement object."""
-        pass
-
-    @abc.abstractmethod
     def __sub__(self, other) -> SoCMeasurement:
         """Produce a single measurement object containing differences across all fields."""
         pass
@@ -65,14 +60,6 @@ class SoC(abc.ABC):
     @abc.abstractmethod
     def getAvailableMetrics(self) -> set[str]:
         """Return a set of all observable metrics on the current processor."""
-        pass
-
-    @abc.abstractmethod
-    def isPresent(self) -> bool:
-        """Return if an SoC is present on the current device.
-
-        This should be true for all derived classes of the `SoC` manager except `EmptySoC`.
-        """
         pass
 
     @abc.abstractmethod
@@ -116,13 +103,6 @@ class EmptySoC(SoC):
     def getAvailableMetrics(self) -> set[str]:
         """Return a set of all observable metrics on the current processor."""
         return set()
-
-    def isPresent(self) -> bool:
-        """Return if an SoC is present on the current device.
-
-        This should be true for all derived classes of the SoC manager except `EmptySoC`.
-        """
-        return False
 
     def getTotalEnergyConsumption(self) -> SoCMeasurement:
         """Returns the total energy consumption of the SoC.

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -199,13 +199,14 @@ class ZeusMonitor:
                 ) from err
             self.cpus = EmptyCPUs()
 
+        self.soc_is_present = False
+
         # Get an SoC instance, if an SoC is present on the host device.
         try:
             self.soc = get_soc()
+            self.soc_is_present = True
         except ZeusSoCInitError:
             self.soc = EmptySoC()
-
-        self.soc_is_present = self.soc.isPresent()
 
         # Resolve GPU indices. If the user did not specify `gpu_indices`, use all available GPUs.
         self.gpu_indices = (

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -199,9 +199,8 @@ class ZeusMonitor:
                 ) from err
             self.cpus = EmptyCPUs()
 
-        self.soc_is_present = False
-
         # Get an SoC instance, if an SoC is present on the host device.
+        self.soc_is_present = False
         try:
             self.soc = get_soc()
             self.soc_is_present = True


### PR DESCRIPTION
## Overview

- Remove `__str__` method from `SoCMeasurement` dataclass
- Remove `isPresent` method from `SoC` monitor class; Zeus energy monitor now uses the outcome of SoC initialization to determine if an SoC is present on host device