### PR TITLE
Apple Silicon Integration

### DIFF
--- a/docs/measure/index.md
+++ b/docs/measure/index.md
@@ -89,7 +89,7 @@ DRAM energy measurement are available on some CPUs as well.
 
 To check CPU/GPU/DRAM measurement support, refer to [Verifying installation](../getting_started/index.md#verifying-installation).
 
-Energy measurement for Apple silicon is supported as well. For more information, refer to [Apple Silicon](#apple-silicon).
+Energy measurement for Apple Silicon is supported as well. For more information, refer to [Apple Silicon](#apple-silicon).
 
 ### [`get_gpus`][zeus.device.get_gpus] and [`get_cpus`][zeus.device.get_cpus]
 
@@ -118,31 +118,32 @@ To only measure the energy consumption of the CPU used by the current Python pro
 
 ### Apple Silicon
 
-To enable Apple silicon energy monitoring, you must have the optional `zeus-apple-silicon` dependency installed.
+To enable Apple Silicon energy monitoring, you must have the optional `zeus-apple-silicon` dependency installed.
 
 If you're installing Zeus for the first time, you can have this dependency installed automatically with
 `pip install 'zeus[apple]'`. You can also install this dependency manually by running `pip install zeus-apple-silicon`. This dependency is maintained in a separate codebase, and you can find more information about it [here](https://github.com/ml-energy/zeus-apple-silicon).
 
-**Note**: if you do not have an Apple silicon processor, are not running macOS, or do not have the above dependency installed, the Zeus monitor will skip measuring energy for Apple silicon.
+**Note**: if you do not have an Apple Silicon processor, are not running macOS, or do not have the above dependency installed, the Zeus monitor will skip measuring energy for Apple Silicon.
 
-Once the dependency is installed, you can conduct measurement as normal with the Zeus monitor ([Programmatic measurement](#programmatic-measurement)), and metrics for Apple silicon will be included in a field called `soc_energy` within the [`Measurement`][zeus.monitor.energy.Measurement] object reported by [`end_window`][zeus.monitor.ZeusMonitor.end_window]. For example:
+Once the dependency is installed, you can conduct measurement as normal with the Zeus monitor ([Programmatic measurement](#programmatic-measurement)), and metrics for Apple Silicon will be included in a field called `soc_energy` within the [`Measurement`][zeus.monitor.energy.Measurement] object reported by [`end_window`][zeus.monitor.ZeusMonitor.end_window]. For example:
 
-```python hl_lines="5 12-14"
+```python
 # ...
 mes = monitor.end_window("epoch")
-apple_results = mes.soc_energy
+apple_energy_metrics = mes.soc_energy
 ```
 
-For Apple silicon, the `soc_energy` field will include metrics for:
-- The on-chip CPU (`soc_energy.cpu_total_mj`)
-- Every efficiency core (`soc_energy.efficiency_cores_mj`)
-- Every performance core (`soc_energy.performance_cores_mj`)
-- Efficiency core manager (`soc_energy.efficiency_core_manager_mj`)
-- Performance core manager (`soc_energy.performance_core_manager_mj`)
-- DRAM (`soc_energy.dram_mj`)
-- The on-chip GPU (`soc_energy.gpu_mj`)
-- GPU SRAM (`soc_energy.gpu_sram_mj`)
-- ANE (`soc_energy.ane_mj`)
+For Apple Silicon, the `soc_energy` field will include metrics for:
+
+- On-chip CPU (`cpu_total_mj`)
+- Every efficiency core (`efficiency_cores_mj`)
+- Every performance core (`performance_cores_mj`)
+- Efficiency core manager (`efficiency_core_manager_mj`)
+- Performance core manager (`performance_core_manager_mj`)
+- DRAM (`dram_mj`)
+- On-chip GPU (`gpu_mj`)
+- GPU SRAM (`gpu_sram_mj`)
+- Apple Neural Engine (ANE) (`ane_mj`)
 
 Note that units are in mJ.
 

--- a/docs/measure/index.md
+++ b/docs/measure/index.md
@@ -89,6 +89,8 @@ DRAM energy measurement are available on some CPUs as well.
 
 To check CPU/GPU/DRAM measurement support, refer to [Verifying installation](../getting_started/index.md#verifying-installation).
 
+Energy measurement for Apple silicon is supported as well. For more information, refer to [Apple Silicon](#apple-silicon).
+
 ### [`get_gpus`][zeus.device.get_gpus] and [`get_cpus`][zeus.device.get_cpus]
 
 The [`get_gpus`][zeus.device.get_gpus] function returns a [`GPUs`][zeus.device.gpu.GPUs] object, which can be either an [`NVIDIAGPUs`][zeus.device.gpu.NVIDIAGPUs] or [`AMDGPUs`][zeus.device.gpu.AMDGPUs] object depending on the availability of `nvml` or `amdsmi`. Each [`GPUs`][zeus.device.gpu.GPUs] object contains one or more [`GPU`][zeus.device.gpu.common.GPU] instances, which are specifically [`NVIDIAGPU`][zeus.device.gpu.nvidia.NVIDIAGPU] or [`AMDGPU`][zeus.device.gpu.amd.AMDGPU] objects.
@@ -113,6 +115,38 @@ Only ROCm >= 6.1 is supported, as the AMDSMI APIs for power and energy return wr
 
 If you have more than one CPU sockets, for instance, running our [environment validation script](../getting_started/index.md#verifying-installation) will show two RAPL devices.
 To only measure the energy consumption of the CPU used by the current Python process, you can use the [`get_current_cpu_index`][zeus.device.cpu.get_current_cpu_index] helper function to retrieve the CPU index where the specified process ID is running and pass in only that index to the `cpu_indices` argument.
+
+### Apple Silicon
+
+To enable Apple silicon energy monitoring, you must have the optional `zeus-apple-silicon` dependency installed.
+
+If you're installing Zeus for the first time, you can have this dependency installed automatically with
+`pip install 'zeus[apple]'`. You can also install this dependency manually by running `pip install zeus-apple-silicon`. This dependency is maintained in a separate codebase, and you can find more information about it [here](https://github.com/ml-energy/zeus-apple-silicon).
+
+**Note**: if you do not have an Apple silicon processor, are not running macOS, or do not have the above dependency installed, the Zeus monitor will skip measuring energy for Apple silicon.
+
+Once the dependency is installed, you can conduct measurement as normal with the Zeus monitor ([Programmatic measurement](#programmatic-measurement)), and metrics for Apple silicon will be included in a field called `soc_energy` within the [`Measurement`][zeus.monitor.energy.Measurement] object reported by [`end_window`][zeus.monitor.ZeusMonitor.end_window]. For example:
+
+```python hl_lines="5 12-14"
+# ...
+mes = monitor.end_window("epoch")
+apple_results = mes.soc_energy
+```
+
+For Apple silicon, the `soc_energy` field will include metrics for:
+- The on-chip CPU (`soc_energy.cpu_total_mj`)
+- Every efficiency core (`soc_energy.efficiency_cores_mj`)
+- Every performance core (`soc_energy.performance_cores_mj`)
+- Efficiency core manager (`soc_energy.efficiency_core_manager_mj`)
+- Performance core manager (`soc_energy.performance_core_manager_mj`)
+- DRAM (`soc_energy.dram_mj`)
+- The on-chip GPU (`soc_energy.gpu_mj`)
+- GPU SRAM (`soc_energy.gpu_sram_mj`)
+- ANE (`soc_energy.ane_mj`)
+
+Note that units are in mJ.
+
+Some metrics may be unavailable for monitoring depending on the specific processor (e.g., DRAM is sometimes unavailable on M1 macs). If a certain subsystem's energy could not be measured, its entry in the result object will simply hold `None`.
 
 ## Metric Monitoring
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,13 +42,13 @@ Documentation = "https://ml.energy/zeus"
 
 [project.optional-dependencies]
 # One day FastAPI will drop support for Pydantic V1. Then fastapi has to be pinned as well.
-apple = ["zeus-apple-silicon"]
 pfo = ["pydantic<2"]
 pfo-server = ["fastapi[standard]", "pydantic<2", "lowtime", "aiofiles", "torch"]
 bso = ["pydantic<2"]
 bso-server = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "python-dotenv"]
 migration = ["alembic", "sqlalchemy", "pydantic<2", "python-dotenv"]
 prometheus = ["prometheus-client"]
+apple = ["zeus-apple-silicon"]
 lint = ["ruff", "black==22.6.0", "pyright!=1.1.395", "pandas-stubs", "transformers"]
 test = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
 docs = ["mkdocs-material[imaging]==9.5.19", "mkdocstrings[python]==0.25.0", "mkdocs-gen-files==0.5.0", "mkdocs-literate-nav==0.6.1", "mkdocs-section-index==0.3.9", "mkdocs-redirects==1.2.1", "urllib3<2", "black"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ Documentation = "https://ml.energy/zeus"
 
 [project.optional-dependencies]
 # One day FastAPI will drop support for Pydantic V1. Then fastapi has to be pinned as well.
+apple = ["zeus-apple-silicon"]
 pfo = ["pydantic<2"]
 pfo-server = ["fastapi[standard]", "pydantic<2", "lowtime", "aiofiles", "torch"]
 bso = ["pydantic<2"]

--- a/tests/device/soc/apple/test_apple.py
+++ b/tests/device/soc/apple/test_apple.py
@@ -1,12 +1,26 @@
 import pytest
+import sys
 from unittest.mock import patch, MagicMock
 from dataclasses import asdict
 
-from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
+
+@pytest.fixture(autouse=True, scope="function")
+def mock_optional_dep():
+    mocked_import = MagicMock()
+    mocked_import.AppleEnergyMonitor = MagicMock()
+    mocked_import.AppleEnergyMetrics = MagicMock()
+    with patch.dict(sys.modules, {"zeus_apple_silicon": mocked_import}):
+        yield
 
 
 @patch("zeus.device.soc.apple.AppleEnergyMonitor")
 def test_total_energy(mocked_energy_monitor):
+
+    # These imports must happen at each test (i.e., function) instead of at
+    # the top of the file because they have an optional dependency that must
+    # be mocked. The `mock_optional_dep` fixture mocks the optional dependency
+    # (zeus_apple_silicon) for all test functions.
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
 
     # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
     mock_monitor = MagicMock()
@@ -49,6 +63,7 @@ def test_total_energy(mocked_energy_monitor):
 
 @patch("zeus.device.soc.apple.AppleEnergyMonitor")
 def test_interval_energy(mocked_energy_monitor):
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
 
     # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
     mock_monitor = MagicMock()
@@ -90,6 +105,7 @@ def test_interval_energy(mocked_energy_monitor):
 
 @patch("zeus.device.soc.apple.AppleEnergyMonitor")
 def test_overlapping_interval_energy(mocked_energy_monitor):
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
 
     # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
     mock_monitor = MagicMock()
@@ -160,6 +176,7 @@ def test_overlapping_interval_energy(mocked_energy_monitor):
 
 @patch("zeus.device.soc.apple.AppleEnergyMonitor")
 def test_available_metrics(mocked_energy_monitor):
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
 
     # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
     mock_monitor = MagicMock()
@@ -192,6 +209,8 @@ def test_available_metrics(mocked_energy_monitor):
 
 
 def test_metrics_subtraction():
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
+
     metrics1 = AppleSiliconMeasurement(
         10, [10, 10, 10], [1, 1, 1], [30], 30, 5, 5, None, 5
     )
@@ -212,6 +231,8 @@ def test_metrics_subtraction():
 
 
 def test_metrics_zero_out():
+    from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
+
     metrics = AppleSiliconMeasurement(10, [10, 10, 10], None, 30, 30, 5, None, None, 5)
     metrics.zeroAllFields()
 

--- a/tests/device/soc/apple/test_apple.py
+++ b/tests/device/soc/apple/test_apple.py
@@ -278,12 +278,12 @@ def test_metrics_zero_out(mock_monitor):
 
     assert metrics.cpu_total_mj == 0
     assert metrics.efficiency_cores_mj == []
-    assert metrics.performance_cores_mj == []
+    assert metrics.performance_cores_mj == None
     assert metrics.efficiency_core_manager_mj == 0
     assert metrics.performance_core_manager_mj == 0
     assert metrics.dram_mj == 0
-    assert metrics.gpu_mj == 0
-    assert metrics.gpu_sram_mj == 0
+    assert metrics.gpu_mj == None
+    assert metrics.gpu_sram_mj == None
     assert metrics.ane_mj == 0
 
 

--- a/tests/device/soc/apple/test_apple.py
+++ b/tests/device/soc/apple/test_apple.py
@@ -9,7 +9,12 @@ def mock_optional_dep():
     mocked_import = MagicMock()
     mocked_import.AppleEnergyMonitor = MagicMock()
     mocked_import.AppleEnergyMetrics = MagicMock()
-    with patch.dict(sys.modules, {"zeus_apple_silicon": mocked_import}):
+
+    with (
+        patch.dict(sys.modules, {"zeus_apple_silicon": mocked_import}),
+        patch("sys.platform", "darwin"),
+        patch("platform.processor", return_value="arm"),
+    ):
         yield
 
 

--- a/tests/device/soc/apple/test_apple.py
+++ b/tests/device/soc/apple/test_apple.py
@@ -1,0 +1,226 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from dataclasses import asdict
+
+from zeus.device.soc.apple import AppleSilicon, AppleSiliconMeasurement
+
+
+@patch("zeus.device.soc.apple.AppleEnergyMonitor")
+def test_total_energy(mocked_energy_monitor):
+
+    # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
+    mock_monitor = MagicMock()
+    mocked_energy_monitor.return_value = mock_monitor
+
+    # Mocking `AppleEnergyMetrics`, not `AppleSiliconMeasurement`
+    mock_metrics = MagicMock(
+        cpu_total_mj=123,
+        efficiency_cores_mj=[1, 2, 3],
+        performance_cores_mj=[11, 22, 33],
+        efficiency_core_manager_mj=123,
+        performance_core_manager_mj=123,
+        dram_mj=123,
+        gpu_mj=123,
+        gpu_sram_mj=123,
+        ane_mj=123,
+    )
+
+    # Specifying return value of `get_cumulative_energy` in `AppleEnergyMonitor`
+    mock_monitor.get_cumulative_energy.return_value = mock_metrics
+
+    monitor = AppleSilicon()
+    res = monitor.getTotalEnergyConsumption()
+
+    res_dict = asdict(res)
+    expected = {
+        "cpu_total_mj": 123,
+        "efficiency_cores_mj": [1, 2, 3],
+        "performance_cores_mj": [11, 22, 33],
+        "efficiency_core_manager_mj": 123,
+        "performance_core_manager_mj": 123,
+        "dram_mj": 123,
+        "gpu_mj": 123,
+        "gpu_sram_mj": 123,
+        "ane_mj": 123,
+    }
+
+    assert res_dict == expected
+
+
+@patch("zeus.device.soc.apple.AppleEnergyMonitor")
+def test_interval_energy(mocked_energy_monitor):
+
+    # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
+    mock_monitor = MagicMock()
+    mocked_energy_monitor.return_value = mock_monitor
+
+    # For `end_window`
+    mock_metrics = MagicMock(
+        cpu_total_mj=100,
+        efficiency_cores_mj=[100, 100, 100],
+        performance_cores_mj=[220, 220, 220],
+        efficiency_core_manager_mj=10,
+        performance_core_manager_mj=20,
+        dram_mj=None,
+        gpu_mj=200,
+        gpu_sram_mj=None,
+        ane_mj=None,
+    )
+    mock_monitor.end_window.return_value = mock_metrics
+
+    monitor = AppleSilicon()
+    monitor.beginWindow("test")
+    res = monitor.endWindow("test")
+
+    res_dict = asdict(res)
+    expected = {
+        "cpu_total_mj": 100,
+        "efficiency_cores_mj": [100, 100, 100],
+        "performance_cores_mj": [220, 220, 220],
+        "efficiency_core_manager_mj": 10,
+        "performance_core_manager_mj": 20,
+        "dram_mj": None,
+        "gpu_mj": 200,
+        "gpu_sram_mj": None,
+        "ane_mj": None,
+    }
+
+    assert res_dict == expected
+
+
+@patch("zeus.device.soc.apple.AppleEnergyMonitor")
+def test_overlapping_interval_energy(mocked_energy_monitor):
+
+    # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
+    mock_monitor = MagicMock()
+    mocked_energy_monitor.return_value = mock_monitor
+
+    # For first `end_window`
+    mock_metrics = MagicMock(
+        cpu_total_mj=100,
+        efficiency_cores_mj=[100, 100, 100],
+        performance_cores_mj=[220, 220, 220],
+        efficiency_core_manager_mj=10,
+        performance_core_manager_mj=20,
+        dram_mj=None,
+        gpu_mj=200,
+        gpu_sram_mj=None,
+        ane_mj=None,
+    )
+    mock_monitor.end_window.return_value = mock_metrics
+
+    monitor = AppleSilicon()
+    monitor.beginWindow("test1")
+    monitor.beginWindow("test2")
+
+    res = monitor.endWindow("test1")
+    res_dict = asdict(res)
+    expected = {
+        "cpu_total_mj": 100,
+        "efficiency_cores_mj": [100, 100, 100],
+        "performance_cores_mj": [220, 220, 220],
+        "efficiency_core_manager_mj": 10,
+        "performance_core_manager_mj": 20,
+        "dram_mj": None,
+        "gpu_mj": 200,
+        "gpu_sram_mj": None,
+        "ane_mj": None,
+    }
+    assert res_dict == expected
+
+    # For second `end_window`
+    mock_metrics = MagicMock(
+        cpu_total_mj=200,
+        efficiency_cores_mj=[200, 100, 100],
+        performance_cores_mj=[220, 220, 220],
+        efficiency_core_manager_mj=10,
+        performance_core_manager_mj=20,
+        dram_mj=None,
+        gpu_mj=800,
+        gpu_sram_mj=None,
+        ane_mj=None,
+    )
+    mock_monitor.end_window.return_value = mock_metrics
+
+    res = monitor.endWindow("test2")
+    res_dict = asdict(res)
+    expected = {
+        "cpu_total_mj": 200,
+        "efficiency_cores_mj": [200, 100, 100],
+        "performance_cores_mj": [220, 220, 220],
+        "efficiency_core_manager_mj": 10,
+        "performance_core_manager_mj": 20,
+        "dram_mj": None,
+        "gpu_mj": 800,
+        "gpu_sram_mj": None,
+        "ane_mj": None,
+    }
+    assert res_dict == expected
+
+
+@patch("zeus.device.soc.apple.AppleEnergyMonitor")
+def test_available_metrics(mocked_energy_monitor):
+
+    # Mocking `AppleEnergyMonitor`, not `AppleSilicon`
+    mock_monitor = MagicMock()
+    mocked_energy_monitor.return_value = mock_monitor
+
+    # `AppleSilicon::getAvailableMetrics` relies on `AppleEnergyMonitor::get_cumulative_energy`.
+    mock_metrics = MagicMock(
+        cpu_total_mj=100,
+        efficiency_cores_mj=[100, 100, 100],
+        performance_cores_mj=None,
+        efficiency_core_manager_mj=None,
+        performance_core_manager_mj=20,
+        dram_mj=None,
+        gpu_mj=200,
+        gpu_sram_mj=None,
+        ane_mj=None,
+    )
+    mock_monitor.get_cumulative_energy.return_value = mock_metrics
+
+    monitor = AppleSilicon()
+    available = monitor.getAvailableMetrics()
+    expected = {
+        "soc.cpu_total_mj",
+        "soc.efficiency_cores_mj",
+        "soc.performance_core_manager_mj",
+        "soc.gpu_mj",
+    }
+
+    assert available == expected
+
+
+def test_metrics_subtraction():
+    metrics1 = AppleSiliconMeasurement(
+        10, [10, 10, 10], [1, 1, 1], [30], 30, 5, 5, None, 5
+    )
+    metrics2 = AppleSiliconMeasurement(
+        20, [100, 110, 100], [1, 1], 30, 40, 5, None, None, 10
+    )
+
+    diff = metrics2 - metrics1
+    assert diff.cpu_total_mj == 10
+    assert diff.efficiency_cores_mj == [90, 100, 90]
+    assert diff.performance_cores_mj == None
+    assert diff.efficiency_core_manager_mj == None
+    assert diff.performance_core_manager_mj == 10
+    assert diff.dram_mj == 0
+    assert diff.gpu_mj is None
+    assert diff.gpu_sram_mj is None
+    assert diff.ane_mj == 5
+
+
+def test_metrics_zero_out():
+    metrics = AppleSiliconMeasurement(10, [10, 10, 10], None, 30, 30, 5, None, None, 5)
+    metrics.zeroAllFields()
+
+    assert metrics.cpu_total_mj == 0
+    assert metrics.efficiency_cores_mj == []
+    assert metrics.performance_cores_mj == []
+    assert metrics.efficiency_core_manager_mj == 0
+    assert metrics.performance_core_manager_mj == 0
+    assert metrics.dram_mj == 0
+    assert metrics.gpu_mj == 0
+    assert metrics.gpu_sram_mj == 0
+    assert metrics.ane_mj == 0

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -29,7 +29,7 @@ def get_soc() -> SoC:
     # --- Apple Silicon ---
     try:
         # The below import is done here instead of at top of file because the
-        # Apple Silicon module contains *optional* dependencies that will cause
+        # Apple Silicon module contains optional dependencies that will cause
         # import failures if not installed on the host device.
         from zeus.device.soc.apple import AppleSilicon, ZeusAppleInitError
 

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -17,17 +17,28 @@ def get_soc() -> SoC:
     The function returns a SoC management object that aims to abstract underlying SoC monitoring
     functionalities.
 
-    Currently, no management object has been implemented for any SoC architecture, so calling this
-    function will raise a `ZeusSoCInitError` error; implementations for SoC devices are expected
-    to be added in the near future.
+    Currently supported SoC devices:
+        - Apple Silicon
+
+    If no SoC monitor object can be initialized, a `ZeusSoCInitError` exception will be raised.
     """
     global _soc
     if _soc is not None:
         return _soc
 
-    # SoCs in the future can be incorporated via `elif` blocks.
-    else:
-        # Placeholder to avoid linting error (remove once _soc can be assigned a real value).
-        _soc = None
+    # --- Apple Silicon ---
+    try:
+        # The below import is done here instead of at top of file because the
+        # Apple Silicon module contains *optional* dependencies that will cause
+        # import failures if not installed on the host device.
+        from zeus.device.soc.apple import AppleSilicon, ZeusAppleInitError
 
+        _soc = AppleSilicon()
+    except (ImportError, ZeusSoCInitError):
+        pass
+
+    # For additional SoC's, add more initialization attempts.
+
+    if _soc is None:
         raise ZeusSoCInitError("No observable SoC was found on the current machine.")
+    return _soc

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -5,8 +5,14 @@ which returns a SoC Manager object specific to the platform.
 """
 
 from __future__ import annotations
+from contextlib import suppress
 
 from zeus.device.soc.common import SoC, ZeusSoCInitError
+from zeus.device.soc.apple import (
+    AppleSilicon,
+    ZeusAppleInitError,
+    apple_silicon_is_available,
+)
 
 _soc: SoC | None = None
 
@@ -27,15 +33,10 @@ def get_soc() -> SoC:
         return _soc
 
     # --- Apple Silicon ---
-    try:
-        # The below import is done here instead of at top of file because the
-        # Apple Silicon module contains optional dependencies that will cause
-        # import failures if not installed on the host device.
-        from zeus.device.soc.apple import AppleSilicon, ZeusAppleInitError
-
-        _soc = AppleSilicon()
-    except (ImportError, ZeusSoCInitError):
-        pass
+    if apple_silicon_is_available():
+        # Equivalent to `try: _, except: pass`
+        with suppress(ZeusAppleInitError):
+            _soc = AppleSilicon()
 
     # For additional SoC's, add more initialization attempts.
 

--- a/zeus/device/soc/__init__.py
+++ b/zeus/device/soc/__init__.py
@@ -5,6 +5,7 @@ which returns a SoC Manager object specific to the platform.
 """
 
 from __future__ import annotations
+
 from contextlib import suppress
 
 from zeus.device.soc.common import SoC, ZeusSoCInitError
@@ -34,7 +35,6 @@ def get_soc() -> SoC:
 
     # --- Apple Silicon ---
     if apple_silicon_is_available():
-        # Equivalent to `try: _, except: pass`
         with suppress(ZeusAppleInitError):
             _soc = AppleSilicon()
 

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -143,7 +143,7 @@ class AppleSilicon(SoC):
 
     def __init__(self) -> None:
         """Initialize an instance of an Apple Silicon energy monitor."""
-        self._monitor: zeus_apple_silicon.AppleEnergyMonitor = None  # type: ignore
+        self._monitor: zeus_apple_silicon.AppleEnergyMonitor  # type: ignore
         self.available_metrics: set[str] | None = None
 
         try:

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -121,7 +121,7 @@ class AppleSiliconMeasurement(SoCMeasurement):
                 setattr(self, f_name, None)
 
     @classmethod
-    def measurementFromMetrics(
+    def from_metrics(
         cls, metrics: zeus_apple_silicon.AppleEnergyMetrics  # type: ignore
     ) -> AppleSiliconMeasurement:
         """Return an AppleSiliconMeasurement object based on an AppleEnergyMetrics object."""
@@ -170,7 +170,7 @@ class AppleSilicon(SoC):
             self.available_metrics = available_metrics
         return self.available_metrics
 
-    def getTotalEnergyConsumption(self) -> SoCMeasurement:
+    def getTotalEnergyConsumption(self) -> AppleSiliconMeasurement:
         """Returns the total energy consumption of the SoC.
 
         The measurement should be cumulative; different calls to this function throughout
@@ -180,13 +180,13 @@ class AppleSilicon(SoC):
         Units: mJ.
         """
         result = self._monitor.get_cumulative_energy()
-        return AppleSiliconMeasurement.measurementFromMetrics(result)
+        return AppleSiliconMeasurement.from_metrics(result)
 
     def beginWindow(self, key) -> None:
         """Begin a measurement interval labeled with `key`."""
         self._monitor.begin_window(key)
 
-    def endWindow(self, key) -> SoCMeasurement:
+    def endWindow(self, key) -> AppleSiliconMeasurement:
         """End a measurement window and return the energy consumption. Units: mJ."""
         result = self._monitor.end_window(key)
-        return AppleSiliconMeasurement.measurementFromMetrics(result)
+        return AppleSiliconMeasurement.from_metrics(result)

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -1,5 +1,7 @@
 """Apple Silicon SoC's."""
 
+from __future__ import annotations
+
 import sys
 import platform
 from dataclasses import dataclass, asdict, fields

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -1,0 +1,146 @@
+"""Apple Silicon SoC's."""
+
+import sys
+import platform
+from dataclasses import dataclass, asdict, fields
+
+from zeus.device.soc.common import SoC, SoCMeasurement, ZeusSoCInitError
+
+from zeus_apple_silicon import AppleEnergyMonitor, AppleEnergyMetrics
+
+
+class ZeusAppleInitError(ZeusSoCInitError):
+    """Import error for Apple SoC initialization failures."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+@dataclass
+class AppleSiliconMeasurement(SoCMeasurement):
+    """Represents energy consumption of various subsystems on an Apple processor.
+
+    All measurements are in mJ.
+    """
+
+    # CPU related metrics
+    cpu_total_mj: int | None = None
+    efficiency_cores_mj: list[int] | None = None
+    performance_cores_mj: list[int] | None = None
+    efficiency_core_manager_mj: int | None = None
+    performance_core_manager_mj: int | None = None
+
+    # DRAM
+    dram_mj: int | None = None
+
+    # GPU related metrics
+    gpu_mj: int | None = None
+    gpu_sram_mj: int | None = None
+
+    # ANE (Apple Neural Engine)
+    ane_mj: int | None = None
+
+    def __sub__(self, other: "AppleSiliconMeasurement") -> "AppleSiliconMeasurement":
+        """Produce a single measurement object containing differences across all fields."""
+        if not isinstance(other, type(self)):
+            raise TypeError(
+                "Subtraction is only supported between AppleSiliconMeasurement instances."
+            )
+
+        result = self.__class__()
+
+        for field in fields(self):
+            f_name = field.name
+            value1 = getattr(self, f_name, None)
+            value2 = getattr(other, f_name, None)
+            if value1 is None or value2 is None or type(value1) is not type(value2):
+                continue
+
+            if isinstance(value1, int):
+                setattr(result, f_name, value1 - value2)
+            elif isinstance(value1, list):
+                if len(value1) != len(value2):
+                    continue
+                setattr(result, f_name, [x - y for x, y in zip(value1, value2)])
+
+        return result
+
+    def zeroAllFields(self) -> None:
+        """Set the value of all fields in the measurement object to zero."""
+        for field in fields(self):
+            f_name = field.name
+            setattr(self, f_name, 0)
+
+        # Handle fields that are meant to be lists specially.
+        list_fields = ["efficiency_cores_mj", "performance_cores_mj"]
+        for f_name in list_fields:
+            f_value = getattr(self, f_name, None)
+            if isinstance(f_value, list):
+                setattr(self, f_name, [0] * len(f_value))
+            else:
+                setattr(self, f_name, [])
+
+
+def measurementFromMetrics(metrics: AppleEnergyMetrics) -> AppleSiliconMeasurement:
+    """Return an AppleSiliconMeasurement object based on an AppleEnergyMetrics object."""
+    return AppleSiliconMeasurement(
+        cpu_total_mj=metrics.cpu_total_mj,
+        efficiency_cores_mj=metrics.efficiency_cores_mj,
+        performance_cores_mj=metrics.performance_cores_mj,
+        efficiency_core_manager_mj=metrics.efficiency_core_manager_mj,
+        performance_core_manager_mj=metrics.performance_core_manager_mj,
+        dram_mj=metrics.dram_mj,
+        gpu_mj=metrics.gpu_mj,
+        gpu_sram_mj=metrics.gpu_sram_mj,
+        ane_mj=metrics.ane_mj,
+    )
+
+
+class AppleSilicon(SoC):
+    """An interface for obtaining energy metrics of an Apple processor."""
+
+    def __init__(self) -> None:
+        """Initialize an instance of an Apple Silicon energy monitor."""
+        self._monitor: AppleEnergyMonitor = None
+        self.available_metrics: set[str] | None = None
+
+        if sys.platform != "darwin" or platform.processor() != "arm":
+            raise ZeusAppleInitError(
+                "AppleSilicon is only supported on Apple silicon devices."
+            )
+
+        try:
+            self._monitor = AppleEnergyMonitor()
+        except RuntimeError as e:
+            raise ZeusAppleInitError(
+                f"Failed to initialize `AppleEnergyMonitor`: {e}"
+            ) from None
+
+        super().__init__()
+
+    def getAvailableMetrics(self) -> set[str]:
+        """Return a set of all observable metrics on the current processor."""
+        if self.available_metrics is None:
+            result: SoCMeasurement = self.getTotalEnergyConsumption()
+            available_metrics = set()
+
+            metrics_dict = asdict(result)
+            for f_name, f_value in metrics_dict.items():
+                if f_value is not None:
+                    available_metrics.add(f"soc.{f_name}")
+
+            self.available_metrics = available_metrics
+        return self.available_metrics
+
+    def getTotalEnergyConsumption(self) -> SoCMeasurement:
+        """Returns the total energy consumption of the SoC.
+
+        The measurement should be cumulative; different calls to this function throughout
+        the lifetime of a single `SoC` manager object should count from a fixed arbitrary
+        point in time.
+
+        Units: mJ.
+        """
+        result: AppleEnergyMetrics = self._monitor.get_cumulative_energy()
+        return measurementFromMetrics(result)

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -8,7 +8,10 @@ from dataclasses import dataclass, asdict, fields
 
 from zeus.device.soc.common import SoC, SoCMeasurement, ZeusSoCInitError
 
-from zeus_apple_silicon import AppleEnergyMonitor, AppleEnergyMetrics
+# The following are optional dependencies. If a host machine does not have them
+# installed, the Zeus code importing this module will gracefully handle the
+# import error.
+from zeus_apple_silicon import AppleEnergyMonitor, AppleEnergyMetrics  # type: ignore
 
 
 class ZeusAppleInitError(ZeusSoCInitError):

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -112,12 +112,13 @@ class AppleSiliconMeasurement(SoCMeasurement):
         """Set the value of all fields in the measurement object to zero."""
         for field in fields(self):
             f_name = field.name
-            setattr(self, f_name, 0)
-
-        # Handle fields that are meant to be lists specially.
-        list_fields = ["efficiency_cores_mj", "performance_cores_mj"]
-        for f_name in list_fields:
-            setattr(self, f_name, [])
+            f_value = getattr(self, f_name)
+            if isinstance(f_value, int):
+                setattr(self, f_name, 0)
+            elif isinstance(f_value, list):
+                setattr(self, f_name, [])
+            else:
+                setattr(self, f_name, None)
 
     @classmethod
     def measurementFromMetrics(

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -117,8 +117,6 @@ class AppleSilicon(SoC):
                 f"Failed to initialize `AppleEnergyMonitor`: {e}"
             ) from None
 
-        super().__init__()
-
     def getAvailableMetrics(self) -> set[str]:
         """Return a set of all observable metrics on the current processor."""
         if self.available_metrics is None:
@@ -144,3 +142,12 @@ class AppleSilicon(SoC):
         """
         result: AppleEnergyMetrics = self._monitor.get_cumulative_energy()
         return measurementFromMetrics(result)
+
+    def beginWindow(self, key) -> None:
+        """Begin a measurement interval labeled with `key`."""
+        self._monitor.begin_window(key)
+
+    def endWindow(self, key) -> SoCMeasurement:
+        """End a measurement window and return the energy consumption. Units: mJ."""
+        res = self._monitor.end_window(key)
+        return measurementFromMetrics(res)

--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -75,11 +75,7 @@ class AppleSiliconMeasurement(SoCMeasurement):
         # Handle fields that are meant to be lists specially.
         list_fields = ["efficiency_cores_mj", "performance_cores_mj"]
         for f_name in list_fields:
-            f_value = getattr(self, f_name, None)
-            if isinstance(f_value, list):
-                setattr(self, f_name, [0] * len(f_value))
-            else:
-                setattr(self, f_name, [])
+            setattr(self, f_name, [])
 
 
 def measurementFromMetrics(metrics: AppleEnergyMetrics) -> AppleSiliconMeasurement:
@@ -149,5 +145,5 @@ class AppleSilicon(SoC):
 
     def endWindow(self, key) -> SoCMeasurement:
         """End a measurement window and return the energy consumption. Units: mJ."""
-        res = self._monitor.end_window(key)
-        return measurementFromMetrics(res)
+        result: AppleEnergyMetrics = self._monitor.end_window(key)
+        return measurementFromMetrics(result)

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -37,6 +37,9 @@ class Measurement:
             window. Each CPU index refers to one powerzone exposed by RAPL (intel-rapl:d)  and DRAM
             measurements are taken from sub-packages within each powerzone. This can be 'None' if
             CPU measurement is not available or DRAM measurement is not available.
+        soc_energy: If your machine contains an SoC (e.g., Apple silicon), metrics for various
+            subsystems of the SoC (e.g., the on-chip CPU, the on-chip GPU) will all be included
+            within this field.
     """
 
     time: float


### PR DESCRIPTION
## Overview

- Integrate `zeus_apple_silicon` into Zeus
- Add additional file `apple.py` under SoC device category
- Modify `__init__.py` in SoC device category to optionally incorporate the new `apple.py` module
- Add tests
- Mark `zeus-apple-silicon` as an optional dependency in `pyproject.toml` (caveat: `zeus-apple-silicon` is currently only available on TestPyPI, though it will be published to the real PyPI very soon)

#### Note about optional dependency:

`__init__.py` in the SoC device directory will try to import the `apple.py` module, but if the user doesn't have `zeus-apple-silicon` installed, `__init__.py` will detect the import error happening and will not try to initialize an instance of `AppleSilicon`; the import error will be caught and not be propagated upstream.

#### Related:

- `zeus-apple-silicon`: https://github.com/ml-energy/zeus-apple-silicon