### PR TITLE
[Feature] Grace Hopper support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ ignore = [
   "PLR2004",  # Magic values
   "SIM115",   # Context manager for opening files
   "E501",     # Line too long
+  "PLC0415",  # Top-level import
 ]
 pydocstyle.convention = "google"
 


### PR DESCRIPTION
On GH200 (Grace Hopper), the cumulative energy counter is for the entire chip/module, which includes not only the GPU, but also CPU, memory, and likely other parts. I think this makes sense not only because the name of the counter is "total" but also it's really a single chip with hardware optimizations spanning the entire CPU/GPU/memory layer, so GPU power likely isn't completely isolated from other parts of the chip.

The Zeus low-level device tree is not adjusted to return power and energy numbers for the entire chip for Grace Hopper. Behavior doesn't change for other types of NVIDIA GPUs.