### PR TITLE
ci: skip ci tests when only markdown files are changed in a push

### DIFF
--- a/.github/workflows/zeus_fmt_lint_test.yaml
+++ b/.github/workflows/zeus_fmt_lint_test.yaml
@@ -21,7 +21,7 @@ on:
       - 'setup.py'
       - 'scripts/lint.sh'
       - 'pyproject.toml'
-    paths-ignore: # if only a .md file is changed, no testing is needed
+    paths-ignore:
       - '**/*.md'
 
 # Jobs initiated by previous pushes get cancelled by a new push.

--- a/.github/workflows/zeus_fmt_lint_test.yaml
+++ b/.github/workflows/zeus_fmt_lint_test.yaml
@@ -21,6 +21,8 @@ on:
       - 'setup.py'
       - 'scripts/lint.sh'
       - 'pyproject.toml'
+    paths-ignore: # if only a .md file is changed, no testing is needed
+      - '**/*.md'
 
 # Jobs initiated by previous pushes get cancelled by a new push.
 concurrency:


### PR DESCRIPTION
### Change Summary
Currently, the `(Zeus) Check format, lint, and test` CI workflow will run even when a push changes **only markdown files** (e.g., README.md).

With these changes, a push that changes *only* markdown files will not trigger the workflow, thus **speeding up the project's CI** and **saving compute resources** 🌱 (see linked issue for quantity).

Fixed #173.