### PR TITLE
Revert "ci: skip ci tests when only markdown files are changed in a push"

### DIFF
--- a/.github/workflows/zeus_fmt_lint_test.yaml
+++ b/.github/workflows/zeus_fmt_lint_test.yaml
@@ -21,8 +21,6 @@ on:
       - 'setup.py'
       - 'scripts/lint.sh'
       - 'pyproject.toml'
-    paths-ignore:
-      - '**/*.md'
 
 # Jobs initiated by previous pushes get cancelled by a new push.
 concurrency:


### PR DESCRIPTION
Reverts ml-energy/zeus#174

https://github.com/ml-energy/zeus/actions/runs/16240237864