### PR TITLE
[UX] Improve `python -m zeus.show_env`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ ignore = [
   "PLR2004",  # Magic values
   "SIM115",   # Context manager for opening files
   "E501",     # Line too long
-  "PLC0415"   # Top-level import
   "PLC0415",  # Top-level import
 ]
 pydocstyle.convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ lint = ["ruff", "black==22.6.0", "pyright!=1.1.395", "pandas-stubs", "transforme
 test = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
 docs = ["mkdocs-material[imaging]==9.5.19", "mkdocstrings[python]==0.25.0", "mkdocs-gen-files==0.5.0", "mkdocs-literate-nav==0.6.1", "mkdocs-section-index==0.3.9", "mkdocs-redirects==1.2.1", "urllib3<2", "black"]
 # greenlet is for supporting apple mac silicon for sqlalchemy(https://docs.sqlalchemy.org/en/20/faq/installation.html)
-dev = ["zeus[pfo-server,bso,bso-server,migration,prometheus,lint,test]", "greenlet"]
+dev = ["zeus[pfo-server,bso,bso-server,migration,prometheus,apple,lint,test,docs]", "greenlet"]
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -84,6 +84,7 @@ ignore = [
   "PLR2004",  # Magic values
   "SIM115",   # Context manager for opening files
   "E501",     # Line too long
+  "PLC0415"   # Top-level import
 ]
 pydocstyle.convention = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,8 @@ lint = ["ruff", "black==22.6.0", "pyright!=1.1.395", "pandas-stubs", "transforme
 test = ["fastapi[standard]", "sqlalchemy", "pydantic<2", "pytest==7.3.2", "pytest-mock==3.10.0", "pytest-xdist==3.3.1", "anyio==3.7.1", "aiosqlite==0.20.0", "numpy<2"]
 docs = ["mkdocs-material[imaging]==9.5.19", "mkdocstrings[python]==0.25.0", "mkdocs-gen-files==0.5.0", "mkdocs-literate-nav==0.6.1", "mkdocs-section-index==0.3.9", "mkdocs-redirects==1.2.1", "urllib3<2", "black"]
 # greenlet is for supporting apple mac silicon for sqlalchemy(https://docs.sqlalchemy.org/en/20/faq/installation.html)
-dev = ["zeus[pfo-server,bso,bso-server,migration,prometheus,apple,lint,test,docs]", "greenlet"]
+# `zeus[apple]` is not included because it can only be installed on MacOS.
+dev = ["zeus[pfo-server,bso,bso-server,migration,prometheus,lint,test,docs]", "greenlet"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -42,7 +42,9 @@ logger = get_logger(name=__name__)
 def amdsmi_is_available() -> bool:
     """Check if amdsmi is available."""
     try:
-        import amdsmi  # type: ignore
+        # `amdsmi` prints to stdout on import when libamd_smi.so is not found.
+        with contextlib.redirect_stdout(None):
+            import amdsmi  # type: ignore
     except ImportError:
         logger.info("amdsmi is not available.")
         return False


### PR DESCRIPTION
Add SoC detection and section separator detects current terminal width. I considered using `rich` but that would get in the way when people have to copy & paste this info into issues.

On my MacBook with no GPUs:
<img width="1718" height="950" alt="Screenshot 2025-07-17 at 6 17 17 PM" src="https://github.com/user-attachments/assets/80e4d2ea-d98f-449a-af87-00be65d12b0c" />
