### PR TITLE
[Zeusd] Check `libnvidia-ml.so.1` if `libnvidia-ml.so` is not available

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -151,6 +151,7 @@ This is also possible for Kubernetes Pods with `securityContext.capabilities.add
 Granting `SYS_ADMIN` to the entire application just to be able to change the GPU's configuration is [granting too much](https://en.wikipedia.org/wiki/Principle_of_least_privilege){.external}.
 Instead, Zeus provides the [**Zeus daemon** or `zeusd`](https://github.com/ml-energy/zeus/tree/master/zeusd){.external}, which is a simple server/daemon process that is designed to run with admin privileges and exposes the minimal set of APIs wrapping NVML methods for changing the GPU's configuration.
 Then, an unprivileged (i.e., run normally by any user) application can ask `zeusd` via a Unix Domain Socket to change the local node's GPU configuration on its behalf.
+The Zeus daemon also supports CPU/DRAM power measurement via Intel RAPL, which normally requires `root` privileges.
 
 To deploy `zeusd`:
 
@@ -190,8 +191,6 @@ Detected:
 
 --------------------------------------------------------------------------------
 ```
-
-The Zeus daemon supports setting the GPU's power limit and frequency, as well as reading CPU/DRAM power measurements via Intel RAPL.
 
 ### Option 3: Running applications with `sudo`
 

--- a/zeusd/src/devices/cpu/linux.rs
+++ b/zeusd/src/devices/cpu/linux.rs
@@ -94,7 +94,7 @@ impl CpuManager for RaplCpu {
     fn get_available_fields(
         index: usize,
     ) -> Result<(Arc<PackageInfo>, Option<Arc<PackageInfo>>), ZeusdError> {
-        let base_path = PathBuf::from(format!("{}/intel-rapl:{}", RAPL_DIR, index));
+        let base_path = PathBuf::from(format!("{RAPL_DIR}/intel-rapl:{index}"));
         let cpu_info = PackageInfo::new(&base_path, index)?;
 
         match fs::read_dir(&base_path) {

--- a/zeusd/src/devices/gpu/linux.rs
+++ b/zeusd/src/devices/gpu/linux.rs
@@ -17,14 +17,16 @@ pub struct NvmlGpu<'n> {
 
 fn init_nvml() -> Result<Nvml, NvmlError> {
     // Initialize NVML and return the instance.
-    if let Ok(nvml) = Nvml::init() {
-        return Ok(nvml);
+    match Nvml::init() {
+        Ok(nvml) => Ok(nvml),
+        Err(NvmlError::LibloadingError(_)) => {
+            tracing::warn!("NVML library not found, trying with `libnvidia-ml.so.1`");
+            Nvml::builder()
+                .lib_path(OsStr::new("libnvidia-ml.so.1"))
+                .init()
+        }
+        Err(e) => Err(e),
     }
-
-    // If initialization fails, try with `libnvidia-ml.so.1`.
-    Nvml::builder()
-        .lib_path(OsStr::new("libnvidia-ml.so.1"))
-        .init()
 }
 
 impl NvmlGpu<'static> {

--- a/zeusd/src/devices/gpu/linux.rs
+++ b/zeusd/src/devices/gpu/linux.rs
@@ -18,14 +18,13 @@ pub struct NvmlGpu<'n> {
 fn init_nvml() -> Result<Nvml, NvmlError> {
     // Initialize NVML and return the instance.
     match Nvml::init() {
-        Ok(nvml) => Ok(nvml),
         Err(NvmlError::LibloadingError(_)) => {
             tracing::warn!("NVML library not found, trying with `libnvidia-ml.so.1`");
             Nvml::builder()
                 .lib_path(OsStr::new("libnvidia-ml.so.1"))
                 .init()
         }
-        Err(e) => Err(e),
+        res => res,
     }
 }
 

--- a/zeusd/src/routes/gpu.rs
+++ b/zeusd/src/routes/gpu.rs
@@ -17,14 +17,14 @@ use crate::error::ZeusdError;
 ///
 /// Gien this, the macro generates
 /// - a request payload struct named API name (e.g., SetPowerLimit) and all the
-///     fields specified plus `block: bool` to indicate whether the request should block,
+///   fields specified plus `block: bool` to indicate whether the request should block,
 /// - an implementation of `From` for the payload struct to convert it to the
 /// - a handler function that takes the request payload, converts it to a `GpuCommand` variant,
-///     and sends it to the `GpuManagementTasks` actor.
+///   and sends it to the `GpuManagementTasks` actor.
 ///
 ///  Assumptions:
 ///  - The `GpuCommand` variant name is the same as the API name, but the former is camel case
-///      and the latter is snake case (e.g., SetPowerLimit vs. set_power_limit).
+///    and the latter is snake case (e.g., SetPowerLimit vs. set_power_limit).
 macro_rules! impl_handler_for_gpu_command {
     ($api:ident, $path:expr, $($field:ident: $ftype:ty,)*) => {
         paste! {

--- a/zeusd/tests/cpu.rs
+++ b/zeusd/tests/cpu.rs
@@ -171,5 +171,5 @@ async fn test_supports_dram_energy() {
 
     let dram_response: DramAvailabilityResponse = serde_json::from_str(&resp.text().await.unwrap())
         .expect("Failed to deserialize response body");
-    assert_eq!(dram_response.dram_available, true);
+    assert!(dram_response.dram_available);
 }

--- a/zeusd/tests/gpu.rs
+++ b/zeusd/tests/gpu.rs
@@ -27,7 +27,7 @@ async fn test_set_persistence_mode_single() {
     assert_eq!(resp.status(), 200);
     let history = app.persistence_mode_history_for_gpu(0);
     assert_eq!(history.len(), 1);
-    assert_eq!(history[0], true);
+    assert!(history[0]);
 }
 
 #[tokio::test]

--- a/zeusd/tests/helpers/mod.rs
+++ b/zeusd/tests/helpers/mod.rs
@@ -285,7 +285,7 @@ impl TestApp {
         let port = listener.local_addr().unwrap().port();
         let server = start_server_tcp(listener, gpu_test_tasks, cpu_test_tasks, 2)
             .expect("Failed to start server");
-        let _ = tokio::spawn(async move { server.await });
+        let _ = tokio::spawn(server);
 
         TestApp {
             port,


### PR DESCRIPTION
NVML first looks for `libnvidia-ml.so` and if it doesn't exist, it'll error. Instead, try falling back to `libnvidia-ml.so.1` and then if that also doesn't exist, bail.