### PR TITLE
Follow logging best practices

### DIFF
--- a/tests/optimizer/batch_size/test_simulator.py
+++ b/tests/optimizer/batch_size/test_simulator.py
@@ -64,15 +64,9 @@ def read_trace(
     return train_df, power_df
 
 
-@pytest.fixture(scope="module", autouse=True)
-def logger_setup():
-    logger = logging.getLogger(
-        "zeus.optimizer.batch_size.server.mab"
-    )  # for testing, propagate the log to the root logger so that caplog can capture
-    logger.propagate = True
-
-
 def test_end_to_end(client, caplog, capsys, mocker: MockerFixture):
+    # Configure caplog to capture INFO level logs from Zeus
+    caplog.set_level(logging.INFO, logger="zeus")
     mocker.patch("httpx.post", side_effect=client.post)
     mocker.patch("httpx.get", side_effect=client.get)
     mocker.patch("httpx.patch", side_effect=client.patch)

--- a/zeus/__init__.py
+++ b/zeus/__init__.py
@@ -11,4 +11,11 @@
 - [`_legacy`][zeus._legacy.policy]: Legacy code mostly to keep our papers reproducible
 """
 
+import logging
+
 __version__ = "0.12.3"
+
+# Add NullHandler to prevent "No handler found" warnings when Zeus is used as a library.
+# Applications using Zeus should configure logging via logging.basicConfig() or by
+# setting up handlers on the root logger.
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/zeus/device/common.py
+++ b/zeus/device/common.py
@@ -6,13 +6,12 @@ import abc
 import os
 import ctypes
 import functools
+import logging
 import warnings
 from typing import Callable
 from functools import lru_cache
 
-from zeus.utils.logging import get_logger
-
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import atexit
+import logging
 import multiprocessing as mp
 import os
 import time
@@ -29,9 +30,8 @@ import httpx
 import zeus.device.cpu.common as cpu_common
 from zeus.device.cpu.common import CpuDramMeasurement
 from zeus.device.exception import ZeusBaseCPUError, ZeusdError
-from zeus.utils.logging import get_logger
 
-logger = get_logger(name=__name__)
+logger = logging.getLogger(__name__)
 
 RAPL_DIR = "/sys/class/powercap/intel-rapl"
 
@@ -80,7 +80,7 @@ class RaplWraparoundTracker:
             raise ValueError(f"{rapl_file_path} is not a valid file path")
 
         # Set up logging.
-        self.logger = get_logger(type(self).__name__)
+        self.logger = logging.getLogger(type(self).__name__)
 
         self.logger.info("Monitoring wrap around of %s", rapl_file_path)
 
@@ -122,6 +122,11 @@ def _polling_process(rapl_file_path: str, max_energy_uj: float, wraparound_count
             if energy_uj < last_energy_uj:
                 with wraparound_counter.get_lock():
                     wraparound_counter.value += 1
+                    logger.debug(
+                        "RAPL wraparound detected for %s; counter now: %d",
+                        rapl_file_path,
+                        wraparound_counter.value,
+                    )
             last_energy_uj = energy_uj
             time.sleep(sleep_time)
     except KeyboardInterrupt:

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -80,9 +80,7 @@ class RaplWraparoundTracker:
             raise ValueError(f"{rapl_file_path} is not a valid file path")
 
         # Set up logging.
-        self.logger = logging.getLogger(type(self).__name__)
-
-        self.logger.info("Monitoring wrap around of %s", rapl_file_path)
+        logger.info("RaplWraparoundTracker is monitoring wrap around of %s", rapl_file_path)
 
         context = mp.get_context("spawn")
         self.wraparound_counter = context.Value("i", 0)

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -1,9 +1,11 @@
 """AMD GPUs."""
 
 from __future__ import annotations
+
 import functools
 import os
 import contextlib
+import logging
 import time
 from typing import Sequence
 from functools import lru_cache
@@ -30,9 +32,8 @@ except Exception:
     amdsmi = MockAMDSMI()
 
 import zeus.device.gpu.common as gpu_common
-from zeus.utils.logging import get_logger
 
-logger = get_logger(name=__name__)
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)

--- a/zeus/device/gpu/common.py
+++ b/zeus/device/gpu/common.py
@@ -3,14 +3,14 @@
 from __future__ import annotations
 
 import abc
+import logging
 import warnings
 from typing import Sequence
 
 from zeus.device.exception import ZeusBaseGPUError
-from zeus.utils.logging import get_logger
 from zeus.device.common import has_sys_admin, deprecated_alias, DeprecatedAliasABCMeta
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class GPU(abc.ABC, metaclass=DeprecatedAliasABCMeta):

--- a/zeus/device/gpu/nvidia.py
+++ b/zeus/device/gpu/nvidia.py
@@ -6,6 +6,7 @@ import os
 import warnings
 import functools
 import contextlib
+import logging
 from pathlib import Path
 from typing import Sequence
 from functools import lru_cache
@@ -15,9 +16,8 @@ import pynvml
 
 import zeus.device.gpu.common as gpu_common
 from zeus.device.exception import ZeusdError
-from zeus.utils.logging import get_logger
 
-logger = get_logger(name=__name__)
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)

--- a/zeus/monitor/carbon.py
+++ b/zeus/monitor/carbon.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import abc
-from dataclasses import dataclass
-from enum import Enum
 import queue
+import logging
 import requests
 import multiprocessing as mp
-
+from dataclasses import dataclass
+from enum import Enum
 from typing import Literal
 from datetime import datetime, timezone, timedelta
 from dateutil import parser
@@ -16,9 +16,8 @@ from collections import defaultdict
 
 from zeus.exception import ZeusBaseError
 from zeus.monitor import ZeusMonitor
-from zeus.utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ZeusCarbonIntensityHTTPError(ZeusBaseError):

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import logging
 import warnings
 from typing import Literal
 from time import time
@@ -11,14 +12,13 @@ from dataclasses import dataclass
 from functools import cached_property
 
 from zeus.monitor.power import PowerMonitor
-from zeus.utils.logging import get_logger
 from zeus.utils.framework import sync_execution as sync_execution_fn
 from zeus.device import get_gpus, get_cpus, get_soc
 from zeus.device.gpu.common import ZeusGPUInitError, EmptyGPUs
 from zeus.device.cpu.common import ZeusCPUInitError, ZeusCPUNoPermissionError, EmptyCPUs
 from zeus.device.soc.common import ZeusSoCInitError, SoCMeasurement, EmptySoC
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @dataclass

--- a/zeus/monitor/power.py
+++ b/zeus/monitor/power.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import bisect
 import collections
+import logging
 import multiprocessing as mp
 import weakref
 from enum import Enum
@@ -15,14 +16,13 @@ from typing import Literal, TYPE_CHECKING
 from sklearn.metrics import auc
 
 from zeus.device.gpu.common import ZeusGPUNotSupportedError
-from zeus.utils.logging import get_logger
 from zeus.device import get_gpus
 
 if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventClass
     from multiprocessing.context import SpawnProcess
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def infer_counter_update_period(gpu_indicies: list[int]) -> float:
@@ -34,8 +34,6 @@ def infer_counter_update_period(gpu_indicies: list[int]) -> float:
     period detected. Then, it returns half the period to ensure that the
     counter is polled at least twice per update period.
     """
-    logger = get_logger(__name__)
-
     gpus = get_gpus()
 
     # For each unique GPU model, infer the update period.

--- a/zeus/monitor/price.py
+++ b/zeus/monitor/price.py
@@ -3,22 +3,21 @@
 from __future__ import annotations
 
 import abc
-from dataclasses import dataclass
-from enum import Enum
 import queue
 import requests
 import json
+import logging
 import multiprocessing as mp
-
+from dataclasses import dataclass
+from enum import Enum
 from typing import Literal
 from datetime import datetime, timezone, timedelta
 from collections import defaultdict
 
 from zeus.exception import ZeusBaseError
 from zeus.monitor import ZeusMonitor
-from zeus.utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def get_time_info() -> tuple[str, str, int]:

--- a/zeus/monitor/temperature.py
+++ b/zeus/monitor/temperature.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import bisect
 import collections
+import logging
 import multiprocessing as mp
 import weakref
 from time import time, sleep
@@ -12,14 +13,13 @@ from queue import Empty
 from typing import TYPE_CHECKING
 
 from zeus.device.gpu.common import ZeusGPUNotSupportedError
-from zeus.utils.logging import get_logger
 from zeus.device import get_gpus
 
 if TYPE_CHECKING:
     from multiprocessing.synchronize import Event as EventClass
     from multiprocessing.context import SpawnProcess
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def _cleanup_temperature_process(

--- a/zeus/optimizer/batch_size/client.py
+++ b/zeus/optimizer/batch_size/client.py
@@ -1,9 +1,12 @@
 """Zeus batch size optimizer client that communicates with server."""
 
 from __future__ import annotations
+
 import atexit
+import logging
 
 import httpx
+
 from zeus.callback import Callback
 from zeus.monitor import ZeusMonitor
 from zeus.optimizer.batch_size.common import (
@@ -25,10 +28,9 @@ from zeus.optimizer.batch_size.exceptions import (
     ZeusBSORuntimError,
     ZeusBSOTrainFailError,
 )
-from zeus.utils.logging import get_logger
 from zeus.device import get_gpus
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class BatchSizeOptimizer(Callback):

--- a/zeus/optimizer/batch_size/server/batch_size_state/repository.py
+++ b/zeus/optimizer/batch_size/server/batch_size_state/repository.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 
 from sqlalchemy import and_, select, func
 from sqlalchemy.ext.asyncio.session import AsyncSession
+
 from zeus.optimizer.batch_size.server.batch_size_state.commands import (
     CreateTrial,
     ReadTrial,
@@ -27,9 +29,8 @@ from zeus.optimizer.batch_size.server.database.schema import (
     TrialType,
 )
 from zeus.optimizer.batch_size.server.exceptions import ZeusBSOValueError
-from zeus.utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class BatchSizeStateRepository(DatabaseRepository):

--- a/zeus/optimizer/batch_size/server/explorer.py
+++ b/zeus/optimizer/batch_size/server/explorer.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from zeus.optimizer.batch_size.server.batch_size_state.commands import (
     CreateConcurrentTrial,
     CreateExplorationTrial,
@@ -15,10 +17,9 @@ from zeus.optimizer.batch_size.server.exceptions import (
 )
 from zeus.optimizer.batch_size.server.job.models import JobState
 from zeus.optimizer.batch_size.server.services.service import ZeusService
-from zeus.utils.logging import get_logger
 from zeus.utils.metric import zeus_cost
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class PruningExploreManager:

--- a/zeus/optimizer/batch_size/server/job/repository.py
+++ b/zeus/optimizer/batch_size/server/job/repository.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio.session import AsyncSession
+
 from zeus.optimizer.batch_size.server.database.repository import DatabaseRepository
 from zeus.optimizer.batch_size.server.database.schema import JobTable
 from zeus.optimizer.batch_size.server.exceptions import (
@@ -18,9 +21,8 @@ from zeus.optimizer.batch_size.server.job.commands import (
     UpdateJobStage,
 )
 from zeus.optimizer.batch_size.server.job.models import JobState
-from zeus.utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class JobStateRepository(DatabaseRepository):

--- a/zeus/optimizer/batch_size/server/mab.py
+++ b/zeus/optimizer/batch_size/server/mab.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
+
 from zeus.optimizer.batch_size.server.batch_size_state.commands import (
     ReadTrial,
     UpdateTrial,
@@ -24,10 +27,9 @@ from zeus.optimizer.batch_size.server.services.commands import (
     UpdateArm,
 )
 from zeus.optimizer.batch_size.server.services.service import ZeusService
-from zeus.utils.logging import get_logger
 from zeus.utils.metric import zeus_cost
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class GaussianTS:

--- a/zeus/optimizer/batch_size/server/optimizer.py
+++ b/zeus/optimizer/batch_size/server/optimizer.py
@@ -1,10 +1,13 @@
 """Batch size optimizer top-most layer that provides register/report/predict."""
 
 from __future__ import annotations
+
 import hashlib
+import logging
 import time
 
 import numpy as np
+
 from zeus.optimizer.batch_size.common import (
     JobSpecFromClient,
     TrialId,
@@ -28,10 +31,9 @@ from zeus.optimizer.batch_size.server.job.commands import CreateJob
 from zeus.optimizer.batch_size.server.job.models import Stage
 from zeus.optimizer.batch_size.server.mab import GaussianTS
 from zeus.optimizer.batch_size.server.services.service import ZeusService
-from zeus.utils.logging import get_logger
 from zeus.utils.metric import zeus_cost
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class ZeusBatchSizeOptimizer:

--- a/zeus/optimizer/batch_size/server/router.py
+++ b/zeus/optimizer/batch_size/server/router.py
@@ -23,7 +23,10 @@ from zeus.optimizer.batch_size.server.database.db_connection import get_db_sessi
 from zeus.optimizer.batch_size.server.exceptions import ZeusBSOServerBaseError
 from zeus.optimizer.batch_size.server.optimizer import ZeusBatchSizeOptimizer
 from zeus.optimizer.batch_size.server.services.service import ZeusService
-from zeus.utils.logging import get_logger
+
+# Configure logging for the server application.
+logging.basicConfig(level=logging.getLevelName(settings.log_level))
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 
@@ -42,10 +45,6 @@ def get_job_locks() -> defaultdict[str, asyncio.Lock]:
 def get_prefix_locks() -> defaultdict[str, asyncio.Lock]:
     """Get global job Id prefix locks."""
     return PREFIX_LOCKS
-
-
-logger = get_logger(__name__)
-logging.basicConfig(level=logging.getLevelName(settings.log_level))
 
 
 @app.post(

--- a/zeus/optimizer/pipeline_frequency/server/job_manager.py
+++ b/zeus/optimizer/pipeline_frequency/server/job_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 import asyncio
+import logging
 import traceback
 
 from fastapi import HTTPException
@@ -18,12 +19,11 @@ from zeus.optimizer.pipeline_frequency.common import (
     save_sched,
     save_ranks,
 )
-from zeus.utils.logging import get_logger
 from zeus.utils.async_utils import create_task
 
 GLOBAL_JOB_MANAGER: JobManager | None = None
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class JobManager:

--- a/zeus/optimizer/pipeline_frequency/server/router.py
+++ b/zeus/optimizer/pipeline_frequency/server/router.py
@@ -8,7 +8,6 @@ from typing import Callable
 from fastapi import Depends, FastAPI, Response, Request
 from fastapi.routing import APIRoute
 
-from zeus.utils.logging import get_logger
 from zeus.optimizer.pipeline_frequency.common import (
     REGISTER_JOB_URL,
     REGISTER_RANK_URL,
@@ -26,7 +25,12 @@ from zeus.optimizer.pipeline_frequency.server.job_manager import (
     get_global_job_manager,
 )
 
-logger = get_logger(__name__)
+settings = PFOServerSettings()
+
+# Configure logging for the server application.
+logging.basicConfig(level=logging.getLevelName(settings.log_level))
+logger = logging.getLogger(__name__)
+
 app = FastAPI()
 
 
@@ -51,8 +55,6 @@ class LoggingRoute(APIRoute):
         return custom_route_handler
 
 
-settings = PFOServerSettings()
-logging.basicConfig(level=logging.getLevelName(settings.log_level))
 if logging.getLevelName(settings.log_level) <= logging.DEBUG:
     app.router.route_class = LoggingRoute
 

--- a/zeus/optimizer/pipeline_frequency/server/scheduler.py
+++ b/zeus/optimizer/pipeline_frequency/server/scheduler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import logging
 from pathlib import Path
 from contextlib import suppress
 from abc import ABC, abstractmethod
@@ -15,9 +16,8 @@ from zeus.optimizer.pipeline_frequency.common import (
     FrequencySchedule,
     ProfilingResult,
 )
-from zeus.utils.logging import get_logger
 
-logger = get_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class FrequencyScheduler(ABC):

--- a/zeus/show_env.py
+++ b/zeus/show_env.py
@@ -29,7 +29,7 @@ from zeus.device.soc.jetson import Jetson
 # Configure logging for the show_env command
 logging.basicConfig(
     level=logging.INFO,
-    format="  %(message)s",  # Simple format for readability in show_env output
+    format="  [%(asctime)s] [%(name)s:%(lineno)d] %(message)s",
 )
 
 SECTION_SEPARATOR = "-" * shutil.get_terminal_size().columns

--- a/zeus/show_env.py
+++ b/zeus/show_env.py
@@ -9,6 +9,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import platform
 import shutil
@@ -25,6 +26,11 @@ from zeus.device.soc.common import ZeusSoCInitError, EmptySoC
 from zeus.device.soc.apple import AppleSilicon
 from zeus.device.soc.jetson import Jetson
 
+# Configure logging for the show_env command
+logging.basicConfig(
+    level=logging.INFO,
+    format="  %(message)s",  # Simple format for readability in show_env output
+)
 
 SECTION_SEPARATOR = "-" * shutil.get_terminal_size().columns
 
@@ -175,7 +181,7 @@ def show_env():
         if platform.system() == "Darwin" and platform.machine() in ["arm64", "aarch64"]:
             soc_availability += (
                 "\nThis appears to be an Apple Silicon device, but it wasn't picked up by Zeus.\n"
-                "Have you installed Zeus with the `apple` extra?\n\n"
+                "Have you installed Zeus with the `apple` extra dependencies?\n"
                 "    pip install 'zeus[apple]'\n"
             )
     print("\nDetected:\n" + soc_availability)

--- a/zeus/show_env.py
+++ b/zeus/show_env.py
@@ -26,12 +26,6 @@ from zeus.device.soc.common import ZeusSoCInitError, EmptySoC
 from zeus.device.soc.apple import AppleSilicon
 from zeus.device.soc.jetson import Jetson
 
-# Configure logging for the show_env command
-logging.basicConfig(
-    level=logging.INFO,
-    format="  [%(asctime)s] [%(name)s:%(lineno)d] %(message)s",
-)
-
 SECTION_SEPARATOR = "-" * shutil.get_terminal_size().columns
 
 
@@ -109,9 +103,9 @@ def show_env():
         physical_indices = [gpu.gpu_index for gpu in gpus.gpus]
 
         # Show device index mapping if env var restricts visibility
-        gpu_availability += "  Device index mapping (Physical (e.g., nvidia-smi) -> Zeus (or any CUDA application)):\n"
+        gpu_availability += "  Device index mapping: Physical (e.g., nvidia-smi) -> Zeus (or any CUDA application)\n"
         for zeus_idx, physical_idx in enumerate(physical_indices):
-            gpu_availability += f"    GPU {physical_idx} -> GPU {zeus_idx}: {gpus.get_name(zeus_idx)}\n"
+            gpu_availability += f"    GPU {physical_idx} -> GPU {zeus_idx} ({gpus.get_name(zeus_idx)})\n"
     else:
         gpu_availability += "  No GPUs available.\n"
     print("\nDetected:\n" + gpu_availability)
@@ -190,4 +184,7 @@ def show_env():
 
 
 if __name__ == "__main__":
+    # For the `python -m zeus.show_env` usage
+    logging.basicConfig(level=logging.INFO, format="  [%(asctime)s] [%(name)s:%(lineno)d] %(message)s")
+
     show_env()

--- a/zeus/utils/async_utils.py
+++ b/zeus/utils/async_utils.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import functools
+import logging
 from typing import Any, Coroutine, TypeVar
 
-from zeus.utils.logging import get_logger
-
 T = TypeVar("T")
-default_logger = get_logger(__name__)
+default_logger = logging.getLogger(__name__)
 
 
 def create_task(

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import types
 from typing import Literal
 from functools import lru_cache
 
-from zeus.utils.logging import get_logger
-
-logger = get_logger(name=__name__)
+logger = logging.getLogger(__name__)
 MODULE_CACHE: dict[str, types.ModuleType] = {}
 
 

--- a/zeus/utils/lat_lon.py
+++ b/zeus/utils/lat_lon.py
@@ -4,7 +4,6 @@ import requests
 import logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 def get_ip_lat_long() -> tuple[float, float]:

--- a/zeus/utils/logging.py
+++ b/zeus/utils/logging.py
@@ -1,8 +1,6 @@
 """Utilities for logging."""
 
-import os
 import sys
-import logging
 from pathlib import Path
 
 
@@ -25,22 +23,3 @@ class FileAndConsole:
         """Flush both log file and stdout."""
         self.file.flush()
         self.stdout.flush()
-
-
-def get_logger(
-    name: str,
-    level: int = logging.INFO,
-    propagate: bool = False,
-) -> logging.Logger:
-    """Get a logger with the given name with some formatting configs."""
-    if name in logging.Logger.manager.loggerDict:
-        return logging.getLogger(name)
-
-    logger = logging.getLogger(name)
-    logger.propagate = propagate
-    logger.setLevel(os.environ.get("ZEUS_LOG_LEVEL", level))
-    formatter = logging.Formatter("[%(asctime)s] [%(name)s](%(filename)s:%(lineno)d) %(message)s")
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    return logger

--- a/zeus/utils/testing.py
+++ b/zeus/utils/testing.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 from zeus.monitor import Measurement, ZeusMonitor
 from zeus.utils.framework import sync_execution as sync_execution_fn
-from zeus.utils.logging import get_logger
 
 
 class ReplayZeusMonitor(ZeusMonitor):
@@ -65,7 +65,7 @@ class ReplayZeusMonitor(ZeusMonitor):
             gpu_indices = [int(gpu.split("_")[0][3:]) for gpu in header.split(",")[3:] if gpu]
         self.nvml_gpu_indices = self.gpu_indices = gpu_indices
 
-        self.logger = get_logger(type(self).__name__)
+        self.logger = logging.getLogger(type(self).__name__)
         self.logger.info("Replaying from '%s' with GPU indices %s", log_file, gpu_indices)
 
         # Keep track of ongoing measurement windows.

--- a/zeus/utils/testing.py
+++ b/zeus/utils/testing.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from zeus.monitor import Measurement, ZeusMonitor
 from zeus.utils.framework import sync_execution as sync_execution_fn
 
+logger = logging.getLogger(__name__)
+
 
 class ReplayZeusMonitor(ZeusMonitor):
     """A mock ZeusMonitor that replays windows recorded by a real monitor.
@@ -65,8 +67,8 @@ class ReplayZeusMonitor(ZeusMonitor):
             gpu_indices = [int(gpu.split("_")[0][3:]) for gpu in header.split(",")[3:] if gpu]
         self.nvml_gpu_indices = self.gpu_indices = gpu_indices
 
-        self.logger = logging.getLogger(type(self).__name__)
-        self.logger.info("Replaying from '%s' with GPU indices %s", log_file, gpu_indices)
+        logger = logging.getLogger(type(self).__name__)
+        logger.info("Replaying from '%s' with GPU indices %s", log_file, gpu_indices)
 
         # Keep track of ongoing measurement windows.
         self.ongoing_windows = []
@@ -89,7 +91,7 @@ class ReplayZeusMonitor(ZeusMonitor):
         if not self.ignore_sync_execution and sync_execution:
             sync_execution_fn(self.gpu_indices)
 
-        self.logger.info("Measurement window '%s' started.", key)
+        logger.info("Measurement window '%s' started.", key)
 
     def end_window(self, key: str, sync_execution: bool = True, cancel: bool = False) -> Measurement:
         """End an ongoing window.
@@ -115,7 +117,7 @@ class ReplayZeusMonitor(ZeusMonitor):
             sync_execution_fn(self.gpu_indices)
 
         if cancel:
-            self.logger.info("Measurement window '%s' cancelled.", key)
+            logger.info("Measurement window '%s' cancelled.", key)
             return Measurement(
                 time=0.0,
                 gpu_energy={gpu_index: 0.0 for gpu_index in self.gpu_indices},
@@ -134,6 +136,6 @@ class ReplayZeusMonitor(ZeusMonitor):
         energy = dict(zip(self.gpu_indices, energy_consumptions))
         measurement = Measurement(time=time_consumption, gpu_energy=energy)
 
-        self.logger.info("Measurement window '%s' ended (%s).", key, measurement)
+        logger.info("Measurement window '%s' ended (%s).", key, measurement)
 
         return measurement

--- a/zeus/utils/testing.py
+++ b/zeus/utils/testing.py
@@ -67,7 +67,6 @@ class ReplayZeusMonitor(ZeusMonitor):
             gpu_indices = [int(gpu.split("_")[0][3:]) for gpu in header.split(",")[3:] if gpu]
         self.nvml_gpu_indices = self.gpu_indices = gpu_indices
 
-        logger = logging.getLogger(type(self).__name__)
         logger.info("Replaying from '%s' with GPU indices %s", log_file, gpu_indices)
 
         # Keep track of ongoing measurement windows.


### PR DESCRIPTION
The old logging facility was committing a fair number of crimes, like disabling `propagate` and calling `logging.basicConfig` as a library.