### PR TITLE
fix: Add deprecated_alias decorator to AppleSiliconMeasurement.zero_all_fields

### DIFF
--- a/zeus/device/soc/apple.py
+++ b/zeus/device/soc/apple.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, asdict, fields
 from functools import lru_cache
 
 from zeus.device.soc.common import SoC, SoCMeasurement, ZeusSoCInitError
+from zeus.device.common import deprecated_alias
 
 try:
     import zeus_apple_silicon  # type: ignore
@@ -102,6 +103,7 @@ class AppleSiliconMeasurement(SoCMeasurement):
 
         return result
 
+    @deprecated_alias("zeroAllFields")
     def zero_all_fields(self) -> None:
         """Set the value of all fields in the measurement object to zero."""
         for field in fields(self):


### PR DESCRIPTION
The AppleSiliconMeasurement class was missing the @deprecated_alias('zeroAllFields') decorator that exists in its parent class SoCMeasurement. This caused a TypeError when instantiating AppleSiliconMeasurement:

```
TypeError: Can't instantiate abstract class AppleSiliconMeasurement without an implementation for abstract method 'zeroAllFields'
```

This fix adds the same decorator to maintain consistency with the parent class.

Fixes: #220