### PR TITLE
[Device] Fix deprecated alias issue for dataclass abstract methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ pydocstyle.convention = "google"
 "zeus/device/gpu/*.py" = ["N802", "N803"]
 "zeus/device/cpu/*.py" = ["N802"]
 "zeus/device/soc/*.py" = ["N802"]
+"zeus/device/common.py" = ["N804"]
 "zeus/utils/testing.py" = ["N802"]
 
 [tool.pytest.ini_options]

--- a/tests/device/test_deprecated_alias.py
+++ b/tests/device/test_deprecated_alias.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 import pytest
+from dataclasses import dataclass
 
 from zeus.device.common import DeprecatedAliasABCMeta, deprecated_alias
 
@@ -34,6 +35,27 @@ class MockDevice(MockDeviceBase):
 
     def set_value(self, value: int) -> None:
         self.value = value
+
+
+@dataclass
+class MockDataclassBase(abc.ABC, metaclass=DeprecatedAliasABCMeta):
+    @deprecated_alias("zeroAllFields")
+    @abc.abstractmethod
+    def zero_all_fields(self) -> None: ...
+
+
+@dataclass
+class MockDataclass(MockDataclassBase):
+    value: int = 0
+
+    def zero_all_fields(self) -> None:
+        self.value = 0
+
+
+def test_dataclass_subclass_is_instantiable():
+    obj = MockDataclass(value=42)
+    obj.zero_all_fields()
+    assert obj.value == 0
 
 
 def test_method_calls():

--- a/zeus/device/common.py
+++ b/zeus/device/common.py
@@ -128,6 +128,11 @@ def _make_deprecated_method(new_method: Callable, old_name: str, new_name: str) 
     if hasattr(deprecated_method, "_deprecated_alias"):
         delattr(deprecated_method, "_deprecated_alias")
 
+    # Since subclasses won't explicitly have an implementation for the deprecated
+    # function, we remove this attribute.
+    if hasattr(deprecated_method, "__isabstractmethod__"):
+        delattr(deprecated_method, "__isabstractmethod__")
+
     return deprecated_method
 
 

--- a/zeus/device/soc/jetson.py
+++ b/zeus/device/soc/jetson.py
@@ -213,7 +213,9 @@ class Jetson(SoC):
             if "power" in metrics:
                 power_measurement[rail] = DirectPower(metrics["power"])  # ty: ignore[invalid-key]
             elif "volt" in metrics and "curr" in metrics:
-                power_measurement[rail] = VoltageCurrentProduct(metrics["volt"], metrics["curr"])  # ty: ignore[invalid-key]
+                power_measurement[rail] = VoltageCurrentProduct(
+                    metrics["volt"], metrics["curr"]
+                )  # ty: ignore[invalid-key]
             # Else, skip the rail due to insufficient metrics for power
         return power_measurement
 

--- a/zeus/device/soc/jetson.py
+++ b/zeus/device/soc/jetson.py
@@ -213,9 +213,7 @@ class Jetson(SoC):
             if "power" in metrics:
                 power_measurement[rail] = DirectPower(metrics["power"])  # ty: ignore[invalid-key]
             elif "volt" in metrics and "curr" in metrics:
-                power_measurement[rail] = VoltageCurrentProduct(
-                    metrics["volt"], metrics["curr"]
-                )  # ty: ignore[invalid-key]
+                power_measurement[rail] = VoltageCurrentProduct(metrics["volt"], metrics["curr"])  # ty: ignore[invalid-key]
             # Else, skip the rail due to insufficient metrics for power
         return power_measurement
 


### PR DESCRIPTION
This PR addresses #220.

For `deprecated_alias`, in `_make_deprecated_method` the deprecated method inherits its attributes from the source function, but the deprecated method that was being created did not have its "is abstract method" attribute cleared. This hasn't caused a problem for GPU and CPU device classes with `deprecated_alias` abstract methods because all the under-the-hood ABC class abstract-method bookkeeping logic occurs *before* "deprecated methods" are created and added to the class in `__new__`, so these deprecated methods were not added to the class's set of abstract methods, avoiding issues.

However, marking a class `@dataclass` causes some additional abstract method updating ([something like this](https://docs.python.org/3/library/abc.html#abc.update_abstractmethods)) to occur after `__new__`, when deprecated methods are added. So, the methods not having their abstract status cleared caused issues.

This solution fixes that by clearing the abstract status attribute from deprecated methods.