### PR TITLE
[Zeusd] `/gpu/get_power` directly to GPU command

### DIFF
--- a/zeusd/src/devices/gpu/mod.rs
+++ b/zeusd/src/devices/gpu/mod.rs
@@ -54,6 +54,7 @@ pub trait GpuManager {
 pub enum GpuResponse {
     Ok,
     Energy { energy_mj: u64 },
+    InstantPower { power_mw: u32 },
 }
 
 /// A request to execute a GPU command.
@@ -185,6 +186,8 @@ pub enum GpuCommand {
     ResetMemLockedClocks,
     /// Get total energy consumption since driver load.
     GetTotalEnergyConsumption,
+    /// Read instantaneous power draw in milliwatts.
+    GetInstantPower,
 }
 
 /// Log the result of a GPU command with timing information.
@@ -311,6 +314,17 @@ impl GpuCommand {
                     "Cannot read total energy consumption",
                 );
                 result.map(|energy_mj| GpuResponse::Energy { energy_mj })
+            }
+            Self::GetInstantPower => {
+                let result = device.get_instant_power_mw();
+                log_command_result(
+                    &result,
+                    request_arrival_time,
+                    command_start_time,
+                    "Instant power read",
+                    "Cannot read instant power",
+                );
+                result.map(|power_mw| GpuResponse::InstantPower { power_mw })
             }
         }
     }

--- a/zeusd/src/routes/gpu.rs
+++ b/zeusd/src/routes/gpu.rs
@@ -1,7 +1,7 @@
 //! Routes for interacting with GPUs
 
-use std::collections::HashMap;
-use std::time::Instant;
+use std::collections::{BTreeMap, HashMap};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use actix_web::web::Bytes;
 use actix_web::{web, HttpResponse};
@@ -265,32 +265,80 @@ fn filter_snapshot(snapshot: &GpuPowerSnapshot, gpu_ids: &Option<Vec<usize>>) ->
 
 /// One-shot GPU power reading.
 ///
-/// Subscribes briefly to wake the poller, waits for a fresh reading (up to
-/// 200 ms), then returns the snapshot as JSON. Optionally filtered by
-/// `gpu_ids` query parameter (comma-separated GPU indices).
+/// Fans out a `GetInstantPower` command to each requested GPU's management
+/// task and returns the collected snapshot as JSON. Optionally filtered by
+/// `gpu_ids` query parameter (comma-separated GPU indices); omit to read all
+/// GPUs.
 #[actix_web::get("/get_power")]
-#[tracing::instrument(skip(broadcast), fields(gpu_ids = ?query.gpu_ids))]
+#[tracing::instrument(skip(query, device_tasks), fields(gpu_ids = ?query.gpu_ids))]
 async fn get_power_handler(
     query: web::Query<GpuReadQuery>,
-    broadcast: web::Data<GpuPowerBroadcast>,
-) -> HttpResponse {
+    device_tasks: web::Data<GpuManagementTasks>,
+) -> Result<HttpResponse, ZeusdError> {
+    let now = Instant::now();
     tracing::info!("Received request");
-    let gpu_ids = query.gpu_ids.as_ref().map(|s| parse_gpu_ids(s));
-    if let Some(ref ids) = gpu_ids {
-        if let Err(unknown) = broadcast.validate_ids(ids) {
-            return HttpResponse::BadRequest().json(serde_json::json!({
-                "error": format!(
-                    "Unknown GPU indices: {:?}. Available: {:?}",
-                    unknown,
-                    broadcast.valid_ids(),
-                )
-            }));
+
+    let device_count = device_tasks.device_count();
+    let gpu_ids: Vec<usize> = match &query.gpu_ids {
+        Some(raw) => {
+            let ids = parse_gpu_ids(raw);
+            if ids.is_empty() {
+                return Ok(HttpResponse::BadRequest().json(serde_json::json!({
+                    "error": "gpu_ids must contain at least one GPU index"
+                })));
+            }
+            for &id in &ids {
+                if id >= device_count {
+                    return Err(ZeusdError::GpuNotFoundError(id));
+                }
+            }
+            ids
+        }
+        None => (0..device_count).collect(),
+    };
+
+    let mut handles = Vec::with_capacity(gpu_ids.len());
+    for &gpu_id in &gpu_ids {
+        let tasks = device_tasks.clone();
+        handles.push(async move {
+            (
+                gpu_id,
+                tasks
+                    .send_command_blocking(gpu_id, GpuCommand::GetInstantPower, now)
+                    .await,
+            )
+        });
+    }
+    let results = futures::future::join_all(handles).await;
+
+    let mut power_mw: BTreeMap<usize, u32> = BTreeMap::new();
+    let mut errors: HashMap<usize, ZeusdError> = HashMap::new();
+    for (gpu_id, result) in results {
+        match result {
+            Ok(GpuResponse::InstantPower { power_mw: p }) => {
+                power_mw.insert(gpu_id, p);
+            }
+            Ok(_) => {
+                errors.insert(gpu_id, ZeusdError::GpuManagementTaskTerminatedError(gpu_id));
+            }
+            Err(e) => {
+                errors.insert(gpu_id, e);
+            }
         }
     }
-    let _guard = broadcast.add_subscriber();
-    let snapshot = broadcast.wait_for_fresh().await.unwrap_or_default();
-    let filtered = filter_snapshot(&snapshot, &gpu_ids);
-    HttpResponse::Ok().json(filtered)
+
+    if !errors.is_empty() {
+        return Ok(aggregate_error_response(errors));
+    }
+
+    let timestamp_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64;
+    Ok(HttpResponse::Ok().json(GpuPowerSnapshot {
+        timestamp_ms,
+        power_mw,
+    }))
 }
 
 /// SSE stream of GPU power readings.

--- a/zeusd/tests/gpu.rs
+++ b/zeusd/tests/gpu.rs
@@ -824,6 +824,32 @@ async fn test_gpu_power_oneshot_has_all_gpus() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gpu_power_oneshot_returns_promptly_with_stable_mock() {
+    // Regression guard: /gpu/get_power must return promptly even when the
+    // underlying device reports a byte-identical power reading on every call.
+    // Multi-thread runtime and the request loop exercise the cross-thread
+    // ordering where a poller-coupled handler is most likely to hang.
+    let _app = TestApp::start().await;
+    let client = reqwest::Client::new();
+    let url = format!("http://127.0.0.1:{}/gpu/get_power", _app.port);
+
+    let inner = async {
+        for _ in 0..10 {
+            let resp = client
+                .get(&url)
+                .send()
+                .await
+                .expect("Failed to send request");
+            assert_eq!(resp.status(), 200);
+        }
+    };
+
+    tokio::time::timeout(std::time::Duration::from_secs(3), inner)
+        .await
+        .expect("/gpu/get_power should return promptly with a stable-power mock");
+}
+
 #[tokio::test]
 async fn test_gpu_power_stream_receives_events() {
     let _app = TestApp::start().await;


### PR DESCRIPTION
Unlike RAPL CPU power, GPU power changes slowly, and there is already a dedicated NVML API for it. No need to get hit by potential race conditions in the poller nor (if unlucky) get hit by constant, idle power change delay on get_power invication.