### PR TITLE
fix: lazily initialize RAPL wraparound monitor process (#121)

### DIFF
--- a/tests/device/cpu/test_rapl.py
+++ b/tests/device/cpu/test_rapl.py
@@ -140,6 +140,48 @@ def test_rapl_file_class(mock_rapl_values, mock_rapl_wraparound_tracker):
     assert raplFile.read() == 580.0  # (80000+5*100000)/1000
 
 
+def test_rapl_file_lazily_initializes_wraparound_tracker():
+    """Test that RAPLFile defers RaplWraparoundTracker creation until the first read()."""
+    path = "/sys/class/powercap/intel-rapl/intel-rapl:0"
+
+    mock_tracker_instance = MagicMock()
+    mock_tracker_instance.get_num_wraparounds.return_value = 0
+
+    mock_name_open = mock_open(read_data="package")
+    mock_energy_open = mock_open(read_data="100000")
+    mock_max_energy_open = mock_open(read_data="200000")
+
+    def mock_file_open(filepath, *args, **kwargs):
+        basename = os.path.basename(filepath)
+        if basename == "name":
+            return mock_name_open()
+        if basename == "energy_uj":
+            return mock_energy_open()
+        if basename == "max_energy_range_uj":
+            return mock_max_energy_open()
+        raise FileNotFoundError(f"Unexpected file: {filepath}")
+
+    with patch("zeus.device.cpu.rapl.RaplWraparoundTracker") as mock_tracker_class, \
+         patch("builtins.open", side_effect=mock_file_open):
+        mock_tracker_class.return_value = mock_tracker_instance
+
+        rapl_file = RAPLFile(path)
+
+        # Tracker must not be created during __init__
+        mock_tracker_class.assert_not_called()
+        assert rapl_file._wraparound_tracker is None
+
+        # First read() must create the tracker exactly once
+        rapl_file.read()
+        mock_tracker_class.assert_called_once()
+        assert rapl_file._wraparound_tracker is mock_tracker_instance
+
+        # Subsequent read() calls must reuse the same tracker instance
+        rapl_file.read()
+        mock_tracker_class.assert_called_once()
+        assert rapl_file._wraparound_tracker is mock_tracker_instance
+
+
 def test_rapl_file_class_exceptions():
     """Test `RAPLFile` Init errors"""
     with patch("builtins.open", mock_open()) as mock_file:

--- a/tests/device/cpu/test_rapl.py
+++ b/tests/device/cpu/test_rapl.py
@@ -161,8 +161,10 @@ def test_rapl_file_lazily_initializes_wraparound_tracker():
             return mock_max_energy_open()
         raise FileNotFoundError(f"Unexpected file: {filepath}")
 
-    with patch("zeus.device.cpu.rapl.RaplWraparoundTracker") as mock_tracker_class, \
-         patch("builtins.open", side_effect=mock_file_open):
+    with (
+        patch("zeus.device.cpu.rapl.RaplWraparoundTracker") as mock_tracker_class,
+        patch("builtins.open", side_effect=mock_file_open),
+    ):
         mock_tracker_class.return_value = mock_tracker_instance
 
         rapl_file = RAPLFile(path)

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -208,6 +208,7 @@ class RAPLFile:
 
     @property
     def wraparound_tracker(self) -> RaplWraparoundTracker:
+        """Return the RaplWraparoundTracker, creating it thread-safely on first access."""
         if self._wraparound_tracker is None:
             with self._lock:
                 if self._wraparound_tracker is None:

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -202,7 +202,13 @@ class RAPLFile:
         except FileNotFoundError as err:
             raise ZeusRAPLFileInitError("Error reading package max energy range") from err
 
-        self.wraparound_tracker = RaplWraparoundTracker(self.energy_uj_path, self.max_energy_range_uj)
+        self._wraparound_tracker: RaplWraparoundTracker | None = None
+
+    @property
+    def wraparound_tracker(self) -> RaplWraparoundTracker:
+        if self._wraparound_tracker is None:
+            self._wraparound_tracker = RaplWraparoundTracker(self.energy_uj_path, self.max_energy_range_uj)
+        return self._wraparound_tracker
 
     def __str__(self) -> str:
         """Return a string representation of the RAPL file object."""

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -204,13 +204,13 @@ class RAPLFile:
             raise ZeusRAPLFileInitError("Error reading package max energy range") from err
 
         self._wraparound_tracker: RaplWraparoundTracker | None = None
-        self._lock = threading.Lock()
+        self._wraparound_tracker_init_lock = threading.Lock()
 
     @property
     def wraparound_tracker(self) -> RaplWraparoundTracker:
         """Return the RaplWraparoundTracker, creating it thread-safely on first access."""
         if self._wraparound_tracker is None:
-            with self._lock:
+            with self._wraparound_tracker_init_lock:
                 if self._wraparound_tracker is None:
                     self._wraparound_tracker = RaplWraparoundTracker(self.energy_uj_path, self.max_energy_range_uj)
         return self._wraparound_tracker

--- a/zeus/device/cpu/rapl.py
+++ b/zeus/device/cpu/rapl.py
@@ -17,6 +17,7 @@ import atexit
 import logging
 import multiprocessing as mp
 import os
+import threading
 import time
 import warnings
 from functools import lru_cache
@@ -203,11 +204,14 @@ class RAPLFile:
             raise ZeusRAPLFileInitError("Error reading package max energy range") from err
 
         self._wraparound_tracker: RaplWraparoundTracker | None = None
+        self._lock = threading.Lock()
 
     @property
     def wraparound_tracker(self) -> RaplWraparoundTracker:
         if self._wraparound_tracker is None:
-            self._wraparound_tracker = RaplWraparoundTracker(self.energy_uj_path, self.max_energy_range_uj)
+            with self._lock:
+                if self._wraparound_tracker is None:
+                    self._wraparound_tracker = RaplWraparoundTracker(self.energy_uj_path, self.max_energy_range_uj)
         return self._wraparound_tracker
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description
Implements lazy initialization of the RAPL wraparound monitor tracker, following the approach @wbjin proposed in #121. `RAPLFile.__init__` now sets `self._wraparound_tracker = None` instead of eagerly creating a `RaplWraparoundTracker` (which spawns a polling child process). A new `wraparound_tracker` property lazily creates the tracker on first access, which happens naturally on the first `read()` call.

## Related Issue
Closes #121

## Motivation and Context
Previously, calling `get_cpus()` instantiated a `RAPLFile` for every CPU/DRAM domain, eagerly spawning one wraparound-monitoring process per domain regardless of whether the caller ever intends to read RAPL energy values. This defers process creation until it's actually needed, exactly as discussed between @jaywonchung and @wbjin in the issue thread, and confirmed by @jaywonchung as the right approach.

## How Has This Been Tested?
Added a new test, `test_rapl_file_lazily_initializes_wraparound_tracker`, which verifies: the tracker is not created during `__init__`, it is created exactly once on the first `read()` call, and subsequent `read()` calls reuse the same tracker instance rather than creating a new one. Ran the full existing test suite in `tests/device/cpu/`; two pre-existing failures (a hardcoded Unix path separator in `test_rapl_file_class`'s fixture, and a missing `pytest-mock` dependency in this local environment) were confirmed unrelated by reverting the change via `git stash` and reproducing the identical failures on the original, unmodified code.

## Types of changes
- [x] Bug fix / enhancement (non-breaking change)