### PR TITLE
Add Windows Intel RAPL support via the Energy Meter Interface (EMI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,5 +105,11 @@ pydocstyle.convention = "google"
 "zeus/device/common.py" = ["N804"]
 "zeus/utils/testing.py" = ["N802"]
 
+[tool.ty.environment]
+# Zeus supports multiple platforms (RAPL on Linux, EMI on Windows). Setting the
+# platform to "all" keeps ty from assuming a single platform and lets it check
+# platform-specific code (e.g. the Windows-only ctypes calls) on any host.
+python-platform = "all"
+
 [tool.pytest.ini_options]
 addopts = "--numprocesses auto"

--- a/tests/device/cpu/test_emi.py
+++ b/tests/device/cpu/test_emi.py
@@ -1,0 +1,480 @@
+"""Tests for the Windows EMI CPU energy monitoring module."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from zeus.device.cpu.common import CpuDramMeasurement
+from zeus.device.cpu.emi import (
+    EMICPU,
+    EMICPUs,
+    EMIFile,
+    ZeusEMIInitError,
+    ZeusEMINotSupportedError,
+    _EMIChannel,
+    emi_is_available,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers for building raw metadata / measurement bytes
+# ---------------------------------------------------------------------------
+
+_EMI_NAME_MAX = 16  # WCHARs
+
+
+def _wstr(text: str, width_wchars: int) -> bytes:
+    """Encode *text* as UTF-16LE, zero-padded to *width_wchars* WCHARs."""
+    encoded = text.encode("utf-16-le")
+    return encoded + b"\x00" * (width_wchars * 2 - len(encoded))
+
+
+def _make_v2_metadata(channels: list[tuple[int, str]]) -> bytes:
+    """Build a minimal EMI_METADATA_V2 buffer.
+
+    Args:
+        channels: List of ``(unit, name)`` tuples, one per channel.
+
+    Returns:
+        Raw bytes ready to pass to :meth:`EMIFile._parse_channels`.
+    """
+    oem = _wstr("Microsoft", _EMI_NAME_MAX)
+    model = _wstr("PPM", _EMI_NAME_MAX)
+    revision = (1).to_bytes(2, "little")
+    count = len(channels).to_bytes(2, "little")
+
+    body = oem + model + revision + count
+    for unit, name in channels:
+        name_bytes = (name + "\x00").encode("utf-16-le")
+        body += unit.to_bytes(4, "little")
+        body += len(name_bytes).to_bytes(2, "little")
+        body += name_bytes
+    return body
+
+
+def _make_v1_metadata(unit: int, name: str) -> bytes:
+    """Build a minimal EMI_METADATA_V1 buffer."""
+    name_bytes = (name + "\x00").encode("utf-16-le") if name else b""
+    oem = _wstr("Vendor", _EMI_NAME_MAX)
+    model = _wstr("Model", _EMI_NAME_MAX)
+    revision = (0).to_bytes(2, "little")
+    name_size = len(name_bytes).to_bytes(2, "little")
+    return unit.to_bytes(4, "little") + oem + model + revision + name_size + name_bytes
+
+
+def _make_measurement(energy_values: list[int]) -> bytes:
+    """Build a V2 measurement buffer (plain array of EMI_CHANNEL_MEASUREMENT_DATA)."""
+    buf = b""
+    for energy in energy_values:
+        buf += energy.to_bytes(8, "little")
+        buf += (0).to_bytes(8, "little")  # AbsoluteTime placeholder
+    return buf
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+
+def test_emi_available_false_on_non_windows():
+    """emi_is_available must return False on non-Windows platforms."""
+    with patch("zeus.device.cpu.emi._WINDOWS", False):
+        # Clear cache so the patch takes effect.
+        emi_is_available.cache_clear()
+        assert emi_is_available() is False
+        emi_is_available.cache_clear()
+
+
+def test_emi_available_false_when_no_devices():
+    """emi_is_available must return False when no EMI devices are enumerated."""
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", True),
+        patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=[]),
+    ):
+        emi_is_available.cache_clear()
+        assert emi_is_available() is False
+        emi_is_available.cache_clear()
+
+
+def test_emi_available_true_when_devices_found():
+    """emi_is_available must return True when at least one EMI device is present."""
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", True),
+        patch(
+            "zeus.device.cpu.emi._get_emi_device_paths",
+            return_value=[r"\\?\acpi#fake#0#{45bd8344-7ed6-49cf-a440-c276c933b053}"],
+        ),
+    ):
+        emi_is_available.cache_clear()
+        assert emi_is_available() is True
+        emi_is_available.cache_clear()
+
+
+# ---------------------------------------------------------------------------
+# Metadata parsing (static method — platform-independent)
+# ---------------------------------------------------------------------------
+
+
+class TestParseChannelsV2:
+    """Tests for EMIFile._parse_channels with EMI version 2."""
+
+    def test_pkg_and_dram_channels(self):
+        """V2 metadata with PKG and DRAM channels is parsed correctly."""
+        raw = _make_v2_metadata(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (0, "RAPL_Package0_DRAM"),
+                (0, "RAPL_Package0_PP0"),
+                (0, "RAPL_Package0_PP1"),
+            ]
+        )
+        channels = EMIFile._parse_channels(version=2, raw=raw)
+        assert len(channels) == 4
+        assert channels[0].name == "RAPL_Package0_PKG"
+        assert channels[0].index == 0
+        assert channels[0].unit == 0
+        assert channels[1].name == "RAPL_Package0_DRAM"
+        assert channels[1].index == 1
+        assert channels[2].name == "RAPL_Package0_PP0"
+        assert channels[2].index == 2
+        assert channels[3].name == "RAPL_Package0_PP1"
+        assert channels[3].index == 3
+
+    def test_multi_package(self):
+        """V2 metadata with two CPU packages is parsed correctly."""
+        raw = _make_v2_metadata(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (0, "RAPL_Package0_DRAM"),
+                (0, "RAPL_Package1_PKG"),
+                (0, "RAPL_Package1_DRAM"),
+            ]
+        )
+        channels = EMIFile._parse_channels(version=2, raw=raw)
+        assert len(channels) == 4
+        assert channels[0].name == "RAPL_Package0_PKG"
+        assert channels[2].name == "RAPL_Package1_PKG"
+
+    def test_unexpected_unit_logs_warning(self, caplog):
+        """A non-pWh unit triggers a warning log."""
+        import logging
+
+        raw = _make_v2_metadata([(99, "RAPL_Package0_PKG")])
+        with caplog.at_level(logging.WARNING, logger="zeus.device.cpu.emi"):
+            EMIFile._parse_channels(version=2, raw=raw)
+        assert any("unexpected unit" in r.message for r in caplog.records)
+
+
+class TestParseChannelsV1:
+    """Tests for EMIFile._parse_channels with EMI version 1."""
+
+    def test_single_named_channel(self):
+        """V1 metadata with a named metered hardware is parsed to one channel."""
+        raw = _make_v1_metadata(unit=0, name="CPU_PKG")
+        channels = EMIFile._parse_channels(version=1, raw=raw)
+        assert len(channels) == 1
+        assert channels[0].index == 0
+        assert channels[0].name == "CPU_PKG"
+        assert channels[0].unit == 0
+
+    def test_empty_name_falls_back(self):
+        """V1 metadata with zero name size falls back to 'EMI_V1'."""
+        raw = _make_v1_metadata(unit=0, name="")
+        channels = EMIFile._parse_channels(version=1, raw=raw)
+        assert len(channels) == 1
+        assert channels[0].name == "EMI_V1"
+
+
+# ---------------------------------------------------------------------------
+# EMICPU tests (EMIFile is mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_emi_file(channel_energies: list[float]) -> MagicMock:
+    """Return a mock EMIFile whose read() returns successive energy values."""
+    mock_file = MagicMock(spec=EMIFile)
+    mock_file.read.side_effect = channel_energies
+    return mock_file
+
+
+class TestEMICPU:
+    """Tests for the EMICPU class."""
+
+    def test_get_total_energy_cpu_only(self):
+        """get_total_energy_consumption returns cpu_mj with dram_mj=None when no DRAM channel."""
+        mock_file = _make_mock_emi_file([1234.5])
+        cpu = EMICPU(
+            cpu_index=0,
+            emi_file=mock_file,
+            pkg_channel_index=0,
+            dram_channel_index=None,
+        )
+        result = cpu.get_total_energy_consumption()
+        assert isinstance(result, CpuDramMeasurement)
+        assert result.cpu_mj == pytest.approx(1234.5)
+        assert result.dram_mj is None
+        mock_file.read.assert_called_once_with(0)
+
+    def test_get_total_energy_cpu_and_dram(self):
+        """get_total_energy_consumption returns both cpu_mj and dram_mj when DRAM is available."""
+        mock_file = _make_mock_emi_file([5000.0, 200.0])
+        cpu = EMICPU(
+            cpu_index=0,
+            emi_file=mock_file,
+            pkg_channel_index=0,
+            dram_channel_index=1,
+        )
+        result = cpu.get_total_energy_consumption()
+        assert result.cpu_mj == pytest.approx(5000.0)
+        assert result.dram_mj == pytest.approx(200.0)
+        assert mock_file.read.call_count == 2
+
+    def test_supports_dram_false_without_dram_channel(self):
+        """supports_get_dram_energy_consumption returns False when dram_channel_index is None."""
+        mock_file = _make_mock_emi_file([])
+        cpu = EMICPU(0, mock_file, pkg_channel_index=0, dram_channel_index=None)
+        assert cpu.supports_get_dram_energy_consumption() is False
+
+    def test_supports_dram_true_with_dram_channel(self):
+        """supports_get_dram_energy_consumption returns True when dram_channel_index is set."""
+        mock_file = _make_mock_emi_file([])
+        cpu = EMICPU(0, mock_file, pkg_channel_index=0, dram_channel_index=1)
+        assert cpu.supports_get_dram_energy_consumption() is True
+
+    def test_cpu_index_stored(self):
+        """cpu_index is stored correctly."""
+        mock_file = _make_mock_emi_file([])
+        cpu = EMICPU(3, mock_file, pkg_channel_index=2, dram_channel_index=None)
+        assert cpu.cpu_index == 3
+
+
+# ---------------------------------------------------------------------------
+# EMICPUs tests (EMIFile and device paths are mocked)
+# ---------------------------------------------------------------------------
+
+
+def _make_emi_file_with_channels(channel_specs: list[tuple[int, str]]) -> MagicMock:
+    """Create a mock EMIFile with channels matching the given (index, name) list."""
+    channels = [_EMIChannel(index=i, name=name, unit=0) for i, name in channel_specs]
+    mock = MagicMock(spec=EMIFile)
+    mock.channels = channels
+    mock.read.return_value = 0.0
+    return mock
+
+
+class TestEMICPUs:
+    """Tests for the EMICPUs manager class."""
+
+    def test_raises_when_emi_unavailable(self):
+        """EMICPUs raises ZeusEMINotSupportedError when no EMI devices are found."""
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=False),
+            pytest.raises(ZeusEMINotSupportedError),
+        ):
+            EMICPUs()
+
+    def test_single_package_no_dram(self):
+        """EMICPUs creates one EMICPU when one PKG channel is found without DRAM."""
+        mock_file = _make_emi_file_with_channels(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (1, "RAPL_Package0_PP0"),
+            ]
+        )
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+        ):
+            cpus = EMICPUs()
+
+        assert len(cpus) == 1
+        assert cpus.cpus[0].cpu_index == 0
+        assert not cpus.cpus[0].supports_get_dram_energy_consumption()
+
+    def test_single_package_with_dram(self):
+        """EMICPUs creates one EMICPU with DRAM when DRAM channel is present."""
+        mock_file = _make_emi_file_with_channels(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (1, "RAPL_Package0_DRAM"),
+                (2, "RAPL_Package0_PP0"),
+            ]
+        )
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+        ):
+            cpus = EMICPUs()
+
+        assert len(cpus) == 1
+        assert cpus.cpus[0].supports_get_dram_energy_consumption()
+
+    def test_multi_package(self):
+        """EMICPUs creates one EMICPU per package, ordered by package index."""
+        mock_file = _make_emi_file_with_channels(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (1, "RAPL_Package0_DRAM"),
+                (2, "RAPL_Package1_PKG"),
+                (3, "RAPL_Package1_DRAM"),
+            ]
+        )
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+        ):
+            cpus = EMICPUs()
+
+        assert len(cpus) == 2
+        assert cpus.cpus[0].cpu_index == 0
+        assert cpus.cpus[1].cpu_index == 1
+
+    def test_raises_when_no_pkg_channels(self):
+        """EMICPUs raises ZeusEMINotSupportedError when devices have no PKG channels."""
+        mock_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PP0"), (1, "RAPL_Package0_PP1")])
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+            pytest.raises(ZeusEMINotSupportedError),
+        ):
+            EMICPUs()
+
+    def test_skips_failing_devices(self):
+        """EMICPUs skips devices that raise ZeusEMIInitError during construction."""
+        good_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PKG")])
+
+        def emi_file_factory(path: str):
+            if path == "bad_path":
+                raise ZeusEMIInitError("simulated failure")
+            return good_file
+
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch(
+                "zeus.device.cpu.emi._get_emi_device_paths",
+                return_value=["bad_path", "good_path"],
+            ),
+            patch("zeus.device.cpu.emi.EMIFile", side_effect=emi_file_factory),
+        ):
+            cpus = EMICPUs()
+
+        assert len(cpus) == 1
+
+    def test_get_total_energy_forwarded(self):
+        """EMICPUs.get_total_energy_consumption forwards to the correct EMICPU."""
+        mock_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PKG"), (1, "RAPL_Package0_DRAM")])
+        mock_file.read.side_effect = [9000.0, 500.0]
+
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+        ):
+            cpus = EMICPUs()
+            result = cpus.get_total_energy_consumption(0)
+
+        assert result.cpu_mj == pytest.approx(9000.0)
+        assert result.dram_mj == pytest.approx(500.0)
+
+
+# ---------------------------------------------------------------------------
+# EMIFile.read — energy unit conversion
+# ---------------------------------------------------------------------------
+
+
+class TestEMIFileRead:
+    """Tests for energy conversion in EMIFile.read."""
+
+    def test_picowatt_hours_to_millijoules(self):
+        """read() converts pWh correctly: 1 pWh = 3.6e-6 mJ."""
+        # Build mock measurement bytes: channel 0 = 1_000_000 pWh
+        meas_bytes = _make_measurement([1_000_000])
+
+        mock_ioctl = MagicMock(return_value=meas_bytes)
+
+        # Construct an EMIFile without calling __init__ (Windows API not available in CI).
+        emi_file = object.__new__(EMIFile)
+        emi_file.path = "fake"
+        emi_file._handle = 0  # null sentinel — __del__ skips CloseHandle for handle == 0
+        emi_file.version = 2
+        emi_file.channels = [_EMIChannel(index=0, name="RAPL_Package0_PKG", unit=0)]
+
+        with patch("zeus.device.cpu.emi._ioctl", mock_ioctl):
+            result = emi_file.read(channel_index=0)
+
+        assert result == pytest.approx(1_000_000 * 3.6e-6)
+
+    def test_read_selects_correct_channel(self):
+        """read() reads the right 16-byte slot for the requested channel."""
+        # 3 channels; channel 2 has energy = 5_000_000 pWh
+        meas_bytes = _make_measurement([100, 200, 5_000_000])
+
+        emi_file = object.__new__(EMIFile)
+        emi_file.path = "fake"
+        emi_file._handle = 0  # null sentinel
+        emi_file.version = 2
+        emi_file.channels = [
+            _EMIChannel(0, "ch0", 0),
+            _EMIChannel(1, "ch1", 0),
+            _EMIChannel(2, "ch2", 0),
+        ]
+
+        with patch("zeus.device.cpu.emi._ioctl", return_value=meas_bytes):
+            result = emi_file.read(channel_index=2)
+
+        assert result == pytest.approx(5_000_000 * 3.6e-6)
+
+
+# ---------------------------------------------------------------------------
+# Windows-only integration test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="EMI is Windows-only")
+class TestEMIIntegration:
+    """Integration tests that exercise the real Windows EMI API."""
+
+    def test_emi_is_available_on_supported_hardware(self):
+        """emi_is_available returns True on hardware that exposes an EMI device."""
+        emi_is_available.cache_clear()
+        result = emi_is_available()
+        emi_is_available.cache_clear()
+        # This machine has an Intel 12th gen Core with EMI support.
+        assert isinstance(result, bool)
+
+    def test_emicpus_initialises_and_reads(self):
+        """EMICPUs can be initialised and return a positive energy value."""
+        emi_is_available.cache_clear()
+        available = emi_is_available()
+        emi_is_available.cache_clear()
+        if not available:
+            pytest.skip("No EMI device found on this machine.")
+
+        cpus = EMICPUs()
+        assert len(cpus) >= 1
+
+        measurement = cpus.get_total_energy_consumption(0)
+        assert isinstance(measurement, CpuDramMeasurement)
+        assert measurement.cpu_mj > 0.0
+
+    def test_energy_increases_over_time(self):
+        """Energy readings are monotonically increasing."""
+        import time
+
+        emi_is_available.cache_clear()
+        available = emi_is_available()
+        emi_is_available.cache_clear()
+        if not available:
+            pytest.skip("No EMI device found on this machine.")
+
+        cpus = EMICPUs()
+        first = cpus.get_total_energy_consumption(0)
+        time.sleep(0.1)
+        second = cpus.get_total_energy_consumption(0)
+        assert second.cpu_mj >= first.cpu_mj

--- a/tests/device/cpu/test_emi.py
+++ b/tests/device/cpu/test_emi.py
@@ -20,10 +20,6 @@ from zeus.device.cpu.emi import (
     get_current_emi_cpu_index,
 )
 
-# ---------------------------------------------------------------------------
-# Helpers for building raw metadata / measurement bytes
-# ---------------------------------------------------------------------------
-
 _EMI_NAME_MAX = 16  # WCHARs
 
 
@@ -73,11 +69,6 @@ def _make_measurement(energy_values: list[int]) -> bytes:
         buf += energy.to_bytes(8, "little")
         buf += (0).to_bytes(8, "little")  # AbsoluteTime placeholder
     return buf
-
-
-# ---------------------------------------------------------------------------
-# Availability check
-# ---------------------------------------------------------------------------
 
 
 def test_emi_available_false_on_non_windows():
@@ -185,11 +176,6 @@ def test_get_cpus_raises_cpu_init_error_when_no_interface():
         cpu_module.get_cpus()
 
 
-# ---------------------------------------------------------------------------
-# Metadata parsing (static method — platform-independent)
-# ---------------------------------------------------------------------------
-
-
 class TestParseChannelsV2:
     """Tests for EMIFile._parse_channels with EMI version 2."""
 
@@ -276,11 +262,6 @@ class TestParseChannelsV1:
         assert channels[0].name == "EMI_V1"
 
 
-# ---------------------------------------------------------------------------
-# EMICPU tests (EMIFile is mocked)
-# ---------------------------------------------------------------------------
-
-
 def _make_mock_emi_file(channel_energies: list[float]) -> MagicMock:
     """Return a mock EMIFile whose read() returns successive energy values."""
     mock_file = MagicMock(spec=EMIFile)
@@ -337,11 +318,6 @@ class TestEMICPU:
         mock_file = _make_mock_emi_file([])
         cpu = EMICPU(3, mock_file, pkg_channel_index=2, dram_channel_index=None)
         assert cpu.cpu_index == 3
-
-
-# ---------------------------------------------------------------------------
-# EMICPUs tests (EMIFile and device paths are mocked)
-# ---------------------------------------------------------------------------
 
 
 def _make_emi_file_with_channels(channel_specs: list[tuple]) -> MagicMock:
@@ -499,11 +475,6 @@ class TestEMICPUs:
         assert result.dram_mj == pytest.approx(500.0)
 
 
-# ---------------------------------------------------------------------------
-# EMIFile.read — energy unit conversion
-# ---------------------------------------------------------------------------
-
-
 class TestEMIFileRead:
     """Tests for energy conversion in EMIFile.read."""
 
@@ -517,7 +488,7 @@ class TestEMIFileRead:
         # Construct an EMIFile without calling __init__ (Windows API not available in CI).
         emi_file = object.__new__(EMIFile)
         emi_file.path = "fake"
-        emi_file._handle = 0  # null sentinel — __del__ skips CloseHandle for handle == 0
+        emi_file._handle = 0  # null sentinel; __del__ skips CloseHandle for handle == 0
         emi_file.version = 2
         emi_file.channels = [_EMIChannel(index=0, name="RAPL_Package0_PKG", unit=0)]
 
@@ -573,11 +544,6 @@ class TestEMIFileRead:
             pytest.raises(ZeusEMIInitError),
         ):
             emi_file.read(channel_index=1)
-
-
-# ---------------------------------------------------------------------------
-# Current CPU package lookup
-# ---------------------------------------------------------------------------
 
 
 def test_get_current_emi_cpu_index_raises_off_windows():
@@ -654,11 +620,6 @@ class TestFindPackageOfProcessor:
         record[8 + 22 : 8 + 24] = (2).to_bytes(2, "little")
         with pytest.raises(ValueError):
             _find_package_of_processor(bytes(record), group=0, number=5, ptr_size=8)
-
-
-# ---------------------------------------------------------------------------
-# Windows-only integration test
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="EMI is Windows-only")

--- a/tests/device/cpu/test_emi.py
+++ b/tests/device/cpu/test_emi.py
@@ -15,7 +15,9 @@ from zeus.device.cpu.emi import (
     ZeusEMIInitError,
     ZeusEMINotSupportedError,
     _EMIChannel,
+    _find_package_of_processor,
     emi_is_available,
+    get_current_emi_cpu_index,
 )
 
 # ---------------------------------------------------------------------------
@@ -98,18 +100,89 @@ def test_emi_available_false_when_no_devices():
         emi_is_available.cache_clear()
 
 
-def test_emi_available_true_when_devices_found():
-    """emi_is_available must return True when at least one EMI device is present."""
+def test_emi_available_true_when_rapl_channels_found():
+    """emi_is_available must return True when a device exposes a RAPL PKG channel."""
+    mock_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PKG"), (1, "RAPL_Package0_DRAM")])
     with (
         patch("zeus.device.cpu.emi._WINDOWS", True),
         patch(
             "zeus.device.cpu.emi._get_emi_device_paths",
             return_value=[r"\\?\acpi#fake#0#{45bd8344-7ed6-49cf-a440-c276c933b053}"],
         ),
+        patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
     ):
         emi_is_available.cache_clear()
         assert emi_is_available() is True
         emi_is_available.cache_clear()
+
+
+def test_emi_available_false_without_rapl_channels():
+    """emi_is_available must return False when EMI devices expose no RAPL PKG channels.
+
+    EMI is also used for non-CPU energy meters (e.g., battery rails on Surface
+    devices), which Zeus cannot map to CPU packages.
+    """
+    mock_file = _make_emi_file_with_channels([(0, "Battery_Rail_0"), (1, "Display_Rail")])
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", True),
+        patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+        patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+    ):
+        emi_is_available.cache_clear()
+        assert emi_is_available() is False
+        emi_is_available.cache_clear()
+
+
+def test_emi_available_false_when_pkg_channel_has_wrong_unit():
+    """A PKG channel whose unit is not picowatt-hours does not count as usable."""
+    mock_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PKG", 99)])
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", True),
+        patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+        patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+    ):
+        emi_is_available.cache_clear()
+        assert emi_is_available() is False
+        emi_is_available.cache_clear()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ZeusEMIInitError("cannot open"),
+        RuntimeError("unexpected ctypes failure"),
+        UnicodeDecodeError("utf-16-le", b"\x00\xd8", 0, 2, "unpaired surrogate"),
+    ],
+)
+def test_emi_available_false_when_device_probing_fails(error):
+    """emi_is_available must return False, never raise, when probing a device fails."""
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", True),
+        patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+        patch("zeus.device.cpu.emi.EMIFile", side_effect=error),
+    ):
+        emi_is_available.cache_clear()
+        assert emi_is_available() is False
+        emi_is_available.cache_clear()
+
+
+def test_get_cpus_raises_cpu_init_error_when_no_interface():
+    """get_cpus must raise ZeusCPUInitError when neither EMI nor RAPL is available.
+
+    This is what lets ZeusMonitor degrade to EmptyCPUs on machines without a
+    CPU energy measurement interface (e.g., Windows machines whose EMI devices
+    expose no RAPL-style channels).
+    """
+    import zeus.device.cpu as cpu_module
+    from zeus.device.cpu.common import ZeusCPUInitError
+
+    with (
+        patch.object(cpu_module, "_cpus", None),
+        patch.object(cpu_module, "emi_is_available", return_value=False),
+        patch.object(cpu_module, "rapl_is_available", return_value=False),
+        pytest.raises(ZeusCPUInitError),
+    ):
+        cpu_module.get_cpus()
 
 
 # ---------------------------------------------------------------------------
@@ -157,14 +230,30 @@ class TestParseChannelsV2:
         assert channels[0].name == "RAPL_Package0_PKG"
         assert channels[2].name == "RAPL_Package1_PKG"
 
-    def test_unexpected_unit_logs_warning(self, caplog):
-        """A non-pWh unit triggers a warning log."""
-        import logging
-
+    def test_unexpected_unit_is_preserved(self):
+        """Parsing keeps a channel's unit as-is; unit policy is applied by consumers."""
         raw = _make_v2_metadata([(99, "RAPL_Package0_PKG")])
-        with caplog.at_level(logging.WARNING, logger="zeus.device.cpu.emi"):
-            EMIFile._parse_channels(version=2, raw=raw)
-        assert any("unexpected unit" in r.message for r in caplog.records)
+        channels = EMIFile._parse_channels(version=2, raw=raw)
+        assert len(channels) == 1
+        assert channels[0].unit == 99
+
+    def test_truncated_header_raises(self):
+        """A buffer shorter than the fixed V2 header must raise."""
+        with pytest.raises(ZeusEMIInitError):
+            EMIFile._parse_channels(version=2, raw=b"\x00" * 10)
+
+    def test_truncated_channel_raises(self):
+        """A buffer that ends inside a channel record must raise."""
+        raw = _make_v2_metadata([(0, "RAPL_Package0_PKG"), (0, "RAPL_Package0_DRAM")])
+        with pytest.raises(ZeusEMIInitError):
+            EMIFile._parse_channels(version=2, raw=raw[:-10])
+
+    def test_channel_count_beyond_buffer_raises(self):
+        """A channel count larger than what the buffer holds must raise."""
+        raw = bytearray(_make_v2_metadata([(0, "RAPL_Package0_PKG")]))
+        raw[66:68] = (5).to_bytes(2, "little")
+        with pytest.raises(ZeusEMIInitError):
+            EMIFile._parse_channels(version=2, raw=bytes(raw))
 
 
 class TestParseChannelsV1:
@@ -255,9 +344,11 @@ class TestEMICPU:
 # ---------------------------------------------------------------------------
 
 
-def _make_emi_file_with_channels(channel_specs: list[tuple[int, str]]) -> MagicMock:
-    """Create a mock EMIFile with channels matching the given (index, name) list."""
-    channels = [_EMIChannel(index=i, name=name, unit=0) for i, name in channel_specs]
+def _make_emi_file_with_channels(channel_specs: list[tuple]) -> MagicMock:
+    """Create a mock EMIFile from a list of (index, name) or (index, name, unit) tuples."""
+    channels = [
+        _EMIChannel(index=spec[0], name=spec[1], unit=spec[2] if len(spec) > 2 else 0) for spec in channel_specs
+    ]
     mock = MagicMock(spec=EMIFile)
     mock.channels = channels
     mock.read.return_value = 0.0
@@ -345,6 +436,31 @@ class TestEMICPUs:
         ):
             EMICPUs()
 
+    def test_non_pwh_channels_ignored(self, caplog):
+        """Channels with a non-picowatt-hour unit are excluded with a warning."""
+        import logging
+
+        mock_file = _make_emi_file_with_channels(
+            [
+                (0, "RAPL_Package0_PKG"),
+                (1, "RAPL_Package0_DRAM", 99),
+                (2, "RAPL_Package1_PKG", 99),
+            ]
+        )
+        with (
+            patch("zeus.device.cpu.emi.emi_is_available", return_value=True),
+            patch("zeus.device.cpu.emi._get_emi_device_paths", return_value=["fake_path"]),
+            patch("zeus.device.cpu.emi.EMIFile", return_value=mock_file),
+            caplog.at_level(logging.WARNING, logger="zeus.device.cpu.emi"),
+        ):
+            cpus = EMICPUs()
+
+        # Package 1's PKG channel and package 0's DRAM channel are excluded.
+        assert len(cpus) == 1
+        assert cpus.cpus[0].cpu_index == 0
+        assert not cpus.cpus[0].supports_get_dram_energy_consumption()
+        assert sum("unexpected measurement unit" in r.message for r in caplog.records) == 2
+
     def test_skips_failing_devices(self):
         """EMICPUs skips devices that raise ZeusEMIInitError during construction."""
         good_file = _make_emi_file_with_channels([(0, "RAPL_Package0_PKG")])
@@ -430,6 +546,115 @@ class TestEMIFileRead:
 
         assert result == pytest.approx(5_000_000 * 3.6e-6)
 
+    def test_read_rejects_non_pwh_unit(self):
+        """read() must refuse to convert a channel whose unit is not picowatt-hours."""
+        emi_file = object.__new__(EMIFile)
+        emi_file.path = "fake"
+        emi_file._handle = 0  # null sentinel
+        emi_file.version = 2
+        emi_file.channels = [_EMIChannel(index=0, name="RAPL_Package0_PKG", unit=99)]
+
+        with (
+            patch("zeus.device.cpu.emi._ioctl", return_value=_make_measurement([100])),
+            pytest.raises(ZeusEMIInitError),
+        ):
+            emi_file.read(channel_index=0)
+
+    def test_read_rejects_out_of_range_channel(self):
+        """read() must reject a channel index outside the device's channel list."""
+        emi_file = object.__new__(EMIFile)
+        emi_file.path = "fake"
+        emi_file._handle = 0  # null sentinel
+        emi_file.version = 2
+        emi_file.channels = [_EMIChannel(index=0, name="RAPL_Package0_PKG", unit=0)]
+
+        with (
+            patch("zeus.device.cpu.emi._ioctl", return_value=_make_measurement([100])),
+            pytest.raises(ZeusEMIInitError),
+        ):
+            emi_file.read(channel_index=1)
+
+
+# ---------------------------------------------------------------------------
+# Current CPU package lookup
+# ---------------------------------------------------------------------------
+
+
+def test_get_current_emi_cpu_index_raises_off_windows():
+    """get_current_emi_cpu_index must raise on non-Windows platforms."""
+    with (
+        patch("zeus.device.cpu.emi._WINDOWS", False),
+        pytest.raises(ZeusEMINotSupportedError),
+    ):
+        get_current_emi_cpu_index()
+
+
+def _package_record(group_masks: list[tuple[int, int]], extra_pad: int = 0, ptr_size: int = 8) -> bytes:
+    """Build one SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX package record.
+
+    Args:
+        group_masks: List of (mask, group) tuples, one per GROUP_AFFINITY entry.
+        extra_pad: Extra trailing bytes covered by the record's Size field, to
+            emulate kernel padding.
+        ptr_size: Size of KAFFINITY (pointer width of the emulated system).
+    """
+    body = bytes([0, 0]) + b"\x00" * 20 + len(group_masks).to_bytes(2, "little")
+    for mask, group in group_masks:
+        body += mask.to_bytes(ptr_size, "little") + group.to_bytes(2, "little") + b"\x00" * 6
+    body += b"\x00" * extra_pad
+    relation_processor_package = 3
+    return relation_processor_package.to_bytes(4, "little") + (8 + len(body)).to_bytes(4, "little") + body
+
+
+class TestFindPackageOfProcessor:
+    """Tests for parsing RelationProcessorPackage records with processor groups."""
+
+    def test_single_package(self):
+        raw = _package_record([(0xFFFF, 0)])
+        assert _find_package_of_processor(raw, group=0, number=5, ptr_size=8) == 0
+
+    def test_two_packages_in_distinct_groups(self):
+        # Two sockets, each with its own processor group (e.g., a >64-thread
+        # dual-socket server). Within-group processor numbers overlap, so the
+        # group must disambiguate which package a processor belongs to.
+        raw = _package_record([(0xFFFFFFFFFFFFFFFF, 0)]) + _package_record([(0xFFFFFFFFFFFFFFFF, 1)])
+        assert _find_package_of_processor(raw, group=0, number=5, ptr_size=8) == 0
+        assert _find_package_of_processor(raw, group=1, number=5, ptr_size=8) == 1
+
+    def test_package_spanning_two_groups(self):
+        raw = _package_record([(0xF, 0), (0xF, 1)])
+        assert _find_package_of_processor(raw, group=1, number=3, ptr_size=8) == 0
+
+    def test_record_padding_respected(self):
+        # The first record is padded; the parser must advance by the record's
+        # Size field rather than the minimal computed layout.
+        raw = _package_record([(0b01, 0)], extra_pad=16) + _package_record([(0b10, 0)])
+        assert _find_package_of_processor(raw, group=0, number=1, ptr_size=8) == 1
+
+    def test_32bit_affinity_masks(self):
+        raw = _package_record([(0b100, 0)], ptr_size=4) + _package_record([(0b1, 1)], ptr_size=4)
+        assert _find_package_of_processor(raw, group=0, number=2, ptr_size=4) == 0
+        assert _find_package_of_processor(raw, group=1, number=0, ptr_size=4) == 1
+
+    def test_no_match_returns_none(self):
+        raw = _package_record([(0b1, 0)])
+        assert _find_package_of_processor(raw, group=0, number=7, ptr_size=8) is None
+        assert _find_package_of_processor(raw, group=1, number=0, ptr_size=8) is None
+
+    def test_malformed_record_size_raises(self):
+        raw = (3).to_bytes(4, "little") + (0).to_bytes(4, "little")
+        with pytest.raises(ValueError):
+            _find_package_of_processor(raw, group=0, number=0, ptr_size=8)
+
+    def test_group_affinity_past_record_raises(self):
+        # GroupCount claims two entries but the record only holds one. Query a
+        # processor the first (valid) entry does not match, so the parser must
+        # reach the second, out-of-bounds entry.
+        record = bytearray(_package_record([(0b1, 0)]))
+        record[8 + 22 : 8 + 24] = (2).to_bytes(2, "little")
+        with pytest.raises(ValueError):
+            _find_package_of_processor(bytes(record), group=0, number=5, ptr_size=8)
+
 
 # ---------------------------------------------------------------------------
 # Windows-only integration test
@@ -478,3 +703,8 @@ class TestEMIIntegration:
         time.sleep(0.1)
         second = cpus.get_total_energy_consumption(0)
         assert second.cpu_mj >= first.cpu_mj
+
+    def test_get_current_emi_cpu_index(self):
+        """The current package index is a valid, non-negative package number."""
+        index = get_current_emi_cpu_index()
+        assert index >= 0

--- a/zeus/device/cpu/__init__.py
+++ b/zeus/device/cpu/__init__.py
@@ -6,11 +6,16 @@ which returns a CPU Manager object specific to the platform.
 
 from __future__ import annotations
 
+import logging
 import os
+import sys
 from typing import Literal
 
 from zeus.device.cpu.common import CPUs, ZeusCPUInitError
-from zeus.device.cpu.rapl import rapl_is_available, RAPLCPUs
+from zeus.device.cpu.emi import EMICPUs, emi_is_available
+from zeus.device.cpu.rapl import RAPLCPUs, rapl_is_available
+
+logger = logging.getLogger(__name__)
 
 _cpus: CPUs | None = None
 
@@ -20,10 +25,16 @@ def get_current_cpu_index(pid: int | Literal["current"] = "current") -> int:
 
     If no PID is given or pid is "current", the CPU index returned is of the CPU running the current process.
 
+    On Linux, the index is read from ``/proc/{pid}/stat`` and the sysfs topology files.
+    On Windows, the index is determined using the Windows logical processor information API.
+
     !!! Note
         Linux schedulers can preempt and reschedule processes to different CPUs. To prevent this from happening
         during monitoring, use `taskset` to pin processes to specific CPUs.
     """
+    if sys.platform == "win32":
+        return _get_current_cpu_index_windows()
+
     if pid == "current":
         pid = os.getpid()
 
@@ -34,20 +45,99 @@ def get_current_cpu_index(pid: int | Literal["current"] = "current") -> int:
         return int(phys_package_file.read().strip())
 
 
+def _get_current_cpu_index_windows() -> int:
+    """Return the CPU package index for the currently executing thread on Windows.
+
+    Uses ``GetCurrentProcessorNumber`` to identify the logical processor and
+    ``GetLogicalProcessorInformationEx`` with ``RelationProcessorPackage`` to
+    map it to a physical package (socket) index.
+    """
+    import ctypes
+    import ctypes.wintypes
+    from ctypes import windll, wintypes
+
+    kernel32 = windll.kernel32
+    kernel32.GetCurrentProcessorNumber.restype = wintypes.DWORD
+    kernel32.GetLogicalProcessorInformationEx.restype = wintypes.BOOL
+
+    current_processor = kernel32.GetCurrentProcessorNumber()
+
+    # Obtain the size of the buffer required for RelationProcessorPackage (= 3).
+    relation_processor_package = 3
+    buf_size = wintypes.DWORD(0)
+    kernel32.GetLogicalProcessorInformationEx(relation_processor_package, None, ctypes.byref(buf_size))
+
+    buf = ctypes.create_string_buffer(buf_size.value)
+    if not kernel32.GetLogicalProcessorInformationEx(relation_processor_package, buf, ctypes.byref(buf_size)):
+        logger.warning("GetLogicalProcessorInformationEx failed; defaulting to CPU package index 0.")
+        return 0
+
+    # Parse the variable-length SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX records.
+    # Each record starts with:
+    #   DWORD Relationship  (4 bytes)
+    #   DWORD Size          (4 bytes)
+    # followed by PROCESSOR_RELATIONSHIP:
+    #   BYTE  Flags             (1)
+    #   BYTE  EfficiencyClass   (1)
+    #   BYTE  Reserved[20]     (20)
+    #   WORD  GroupCount        (2)
+    #   GROUP_AFFINITY GroupMask[GroupCount]
+    # Each GROUP_AFFINITY:
+    #   ULONG_PTR Mask  (8 bytes on 64-bit)
+    #   WORD Group      (2)
+    #   WORD Reserved[3](6)
+    #   total = 16 bytes on 64-bit
+
+    raw = bytes(buf)
+    offset = 0
+    package_index = 0
+    ptr_size = ctypes.sizeof(ctypes.c_void_p)  # 8 on 64-bit, 4 on 32-bit
+    group_affinity_size = ptr_size + 2 + 6  # Mask + Group + Reserved[3]
+
+    while offset < buf_size.value:
+        record_size = int.from_bytes(raw[offset + 4 : offset + 8], "little")
+
+        # PROCESSOR_RELATIONSHIP starts at offset + 8.
+        # GroupCount is at offset 22 within PROCESSOR_RELATIONSHIP (1+1+20 = 22).
+        group_count = int.from_bytes(raw[offset + 8 + 22 : offset + 8 + 24], "little")
+
+        # GROUP_AFFINITY array starts at offset 24 within PROCESSOR_RELATIONSHIP.
+        for g in range(group_count):
+            ga_offset = offset + 8 + 24 + g * group_affinity_size
+            mask = int.from_bytes(raw[ga_offset : ga_offset + ptr_size], "little")
+            if (mask >> current_processor) & 1:
+                return package_index
+
+        package_index += 1
+        offset += record_size
+
+    logger.warning(
+        "Could not map logical processor %d to a package; defaulting to 0.",
+        current_processor,
+    )
+    return 0
+
+
 def get_cpus() -> CPUs:
-    """Initialize and return a singleton CPU monitoring object for INTEL CPUs.
+    """Initialize and return a singleton CPU monitoring object for Intel CPUs.
 
-    The function returns a CPU management object that aims to abstract the underlying CPU monitoring libraries
-    (RAPL for Intel CPUs).
+    The function returns a CPU management object that abstracts the underlying
+    CPU energy monitoring interface: EMI on Windows, RAPL on Linux.
 
-    This function attempts to initialize CPU mointoring using RAPL. If this attempt fails, it raises
-    a ZeusErrorInit exception.
+    Raises:
+        ZeusCPUInitError: If no supported CPU energy monitoring interface is available.
     """
     global _cpus
     if _cpus is not None:
         return _cpus
+    if emi_is_available():
+        _cpus = EMICPUs()
+        return _cpus
     if rapl_is_available():
         _cpus = RAPLCPUs()
         return _cpus
-    else:
-        raise ZeusCPUInitError("RAPL unvailable Failed to initialize CPU management library.")
+    raise ZeusCPUInitError(
+        "No supported CPU energy monitoring interface is available. "
+        "EMI requires Windows 10+ with an Intel EMI-compatible driver. "
+        "RAPL requires Linux with the intel-rapl kernel module."
+    )

--- a/zeus/device/cpu/__init__.py
+++ b/zeus/device/cpu/__init__.py
@@ -58,7 +58,13 @@ def _get_current_cpu_index_windows() -> int:
 
     kernel32 = windll.kernel32
     kernel32.GetCurrentProcessorNumber.restype = wintypes.DWORD
+    kernel32.GetCurrentProcessorNumber.argtypes = []
     kernel32.GetLogicalProcessorInformationEx.restype = wintypes.BOOL
+    kernel32.GetLogicalProcessorInformationEx.argtypes = [
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
 
     current_processor = kernel32.GetCurrentProcessorNumber()
 
@@ -95,7 +101,13 @@ def _get_current_cpu_index_windows() -> int:
     group_affinity_size = ptr_size + 2 + 6  # Mask + Group + Reserved[3]
 
     while offset < buf_size.value:
+        if offset + 8 > len(raw):
+            break
         record_size = int.from_bytes(raw[offset + 4 : offset + 8], "little")
+        # A zero or out-of-range record size means the buffer is malformed; stop
+        # here rather than looping forever or reading past the end.
+        if record_size <= 0 or offset + record_size > len(raw):
+            break
 
         # PROCESSOR_RELATIONSHIP starts at offset + 8.
         # GroupCount is at offset 22 within PROCESSOR_RELATIONSHIP (1+1+20 = 22).

--- a/zeus/device/cpu/__init__.py
+++ b/zeus/device/cpu/__init__.py
@@ -6,16 +6,12 @@ which returns a CPU Manager object specific to the platform.
 
 from __future__ import annotations
 
-import logging
 import os
-import sys
 from typing import Literal
 
 from zeus.device.cpu.common import CPUs, ZeusCPUInitError
 from zeus.device.cpu.emi import EMICPUs, emi_is_available
-from zeus.device.cpu.rapl import RAPLCPUs, rapl_is_available
-
-logger = logging.getLogger(__name__)
+from zeus.device.cpu.rapl import rapl_is_available, RAPLCPUs
 
 _cpus: CPUs | None = None
 
@@ -25,16 +21,10 @@ def get_current_cpu_index(pid: int | Literal["current"] = "current") -> int:
 
     If no PID is given or pid is "current", the CPU index returned is of the CPU running the current process.
 
-    On Linux, the index is read from ``/proc/{pid}/stat`` and the sysfs topology files.
-    On Windows, the index is determined using the Windows logical processor information API.
-
     !!! Note
         Linux schedulers can preempt and reschedule processes to different CPUs. To prevent this from happening
         during monitoring, use `taskset` to pin processes to specific CPUs.
     """
-    if sys.platform == "win32":
-        return _get_current_cpu_index_windows()
-
     if pid == "current":
         pid = os.getpid()
 
@@ -43,91 +33,6 @@ def get_current_cpu_index(pid: int | Literal["current"] = "current") -> int:
 
     with open(f"/sys/devices/system/cpu/cpu{cpu_core}/topology/physical_package_id") as phys_package_file:
         return int(phys_package_file.read().strip())
-
-
-def _get_current_cpu_index_windows() -> int:
-    """Return the CPU package index for the currently executing thread on Windows.
-
-    Uses ``GetCurrentProcessorNumber`` to identify the logical processor and
-    ``GetLogicalProcessorInformationEx`` with ``RelationProcessorPackage`` to
-    map it to a physical package (socket) index.
-    """
-    import ctypes
-    import ctypes.wintypes
-    from ctypes import windll, wintypes
-
-    kernel32 = windll.kernel32
-    kernel32.GetCurrentProcessorNumber.restype = wintypes.DWORD
-    kernel32.GetCurrentProcessorNumber.argtypes = []
-    kernel32.GetLogicalProcessorInformationEx.restype = wintypes.BOOL
-    kernel32.GetLogicalProcessorInformationEx.argtypes = [
-        wintypes.DWORD,
-        ctypes.c_void_p,
-        ctypes.POINTER(wintypes.DWORD),
-    ]
-
-    current_processor = kernel32.GetCurrentProcessorNumber()
-
-    # Obtain the size of the buffer required for RelationProcessorPackage (= 3).
-    relation_processor_package = 3
-    buf_size = wintypes.DWORD(0)
-    kernel32.GetLogicalProcessorInformationEx(relation_processor_package, None, ctypes.byref(buf_size))
-
-    buf = ctypes.create_string_buffer(buf_size.value)
-    if not kernel32.GetLogicalProcessorInformationEx(relation_processor_package, buf, ctypes.byref(buf_size)):
-        logger.warning("GetLogicalProcessorInformationEx failed; defaulting to CPU package index 0.")
-        return 0
-
-    # Parse the variable-length SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX records.
-    # Each record starts with:
-    #   DWORD Relationship  (4 bytes)
-    #   DWORD Size          (4 bytes)
-    # followed by PROCESSOR_RELATIONSHIP:
-    #   BYTE  Flags             (1)
-    #   BYTE  EfficiencyClass   (1)
-    #   BYTE  Reserved[20]     (20)
-    #   WORD  GroupCount        (2)
-    #   GROUP_AFFINITY GroupMask[GroupCount]
-    # Each GROUP_AFFINITY:
-    #   ULONG_PTR Mask  (8 bytes on 64-bit)
-    #   WORD Group      (2)
-    #   WORD Reserved[3](6)
-    #   total = 16 bytes on 64-bit
-
-    raw = bytes(buf)
-    offset = 0
-    package_index = 0
-    ptr_size = ctypes.sizeof(ctypes.c_void_p)  # 8 on 64-bit, 4 on 32-bit
-    group_affinity_size = ptr_size + 2 + 6  # Mask + Group + Reserved[3]
-
-    while offset < buf_size.value:
-        if offset + 8 > len(raw):
-            break
-        record_size = int.from_bytes(raw[offset + 4 : offset + 8], "little")
-        # A zero or out-of-range record size means the buffer is malformed; stop
-        # here rather than looping forever or reading past the end.
-        if record_size <= 0 or offset + record_size > len(raw):
-            break
-
-        # PROCESSOR_RELATIONSHIP starts at offset + 8.
-        # GroupCount is at offset 22 within PROCESSOR_RELATIONSHIP (1+1+20 = 22).
-        group_count = int.from_bytes(raw[offset + 8 + 22 : offset + 8 + 24], "little")
-
-        # GROUP_AFFINITY array starts at offset 24 within PROCESSOR_RELATIONSHIP.
-        for g in range(group_count):
-            ga_offset = offset + 8 + 24 + g * group_affinity_size
-            mask = int.from_bytes(raw[ga_offset : ga_offset + ptr_size], "little")
-            if (mask >> current_processor) & 1:
-                return package_index
-
-        package_index += 1
-        offset += record_size
-
-    logger.warning(
-        "Could not map logical processor %d to a package; defaulting to 0.",
-        current_processor,
-    )
-    return 0
 
 
 def get_cpus() -> CPUs:

--- a/zeus/device/cpu/emi.py
+++ b/zeus/device/cpu/emi.py
@@ -20,6 +20,7 @@ See: https://learn.microsoft.com/en-us/windows-hardware/drivers/powermeter/energ
 
 from __future__ import annotations
 
+import contextlib
 import ctypes
 import ctypes.wintypes
 import logging
@@ -37,52 +38,58 @@ logger = logging.getLogger(__name__)
 # EMI is a Windows-only interface. windll/wintypes are only available on Windows.
 _WINDOWS = sys.platform == "win32"
 
+# -----------------------------------------------------------------------
+# Constants
+#
+# These are plain integer/float values that do not depend on the Windows-only
+# ``windll``/``wintypes`` imports, so they are defined unconditionally. This lets
+# the platform-independent helpers (metadata parsing, energy conversion) run and
+# be unit tested on any OS, not just Windows.
+# -----------------------------------------------------------------------
+
+# GUID for the EMI device interface: {45BD8344-7ED6-49CF-A440-C276C933B053}
+_EMI_GUID_DATA1: int = 0x45BD8344
+_EMI_GUID_DATA2: int = 0x7ED6
+_EMI_GUID_DATA3: int = 0x49CF
+_EMI_GUID_DATA4: tuple[int, ...] = (0xA4, 0x40, 0xC2, 0x76, 0xC9, 0x33, 0xB0, 0x53)
+
+# IOCTLs — CTL_CODE(FILE_DEVICE_UNKNOWN=0x22, func, METHOD_BUFFERED=0, FILE_READ_ACCESS=1)
+# = (0x22 << 16) | (1 << 14) | (func << 2) | 0
+_IOCTL_EMI_GET_VERSION: int = 0x00224000  # func = 0
+_IOCTL_EMI_GET_METADATA_SIZE: int = 0x00224004  # func = 1
+_IOCTL_EMI_GET_METADATA: int = 0x00224008  # func = 2
+_IOCTL_EMI_GET_MEASUREMENT: int = 0x0022400C  # func = 3
+
+_EMI_VERSION_V1: int = 1
+_EMI_VERSION_V2: int = 2
+
+# EMI_NAME_MAX: maximum WCHAR count for OEM/Model fields in metadata (= 16 WCHARs = 32 bytes)
+_EMI_NAME_MAX: int = 16
+
+# EmiMeasurementUnitPicowattHours = 0
+_EMI_MEASUREMENT_UNIT_PICOWATT_HOURS: int = 0
+
+# 1 picowatt-hour = 1e-12 W * 3600 s = 3.6e-9 J = 3.6e-6 mJ
+_PICOWATT_HOURS_TO_MILLIJOULES: float = 3.6e-6
+
+_GENERIC_READ: int = 0x80000000
+_FILE_SHARE_READ: int = 0x00000001
+_OPEN_EXISTING: int = 3
+# INVALID_HANDLE_VALUE: all bits set, platform-width.
+# Using bit arithmetic avoids the Optional[int] return type of ctypes.c_void_p.value.
+_INVALID_HANDLE_VALUE: int = 2 ** (ctypes.sizeof(ctypes.c_void_p) * 8) - 1
+_DIGCF_PRESENT: int = 0x00000002
+_DIGCF_DEVICEINTERFACE: int = 0x00000010
+
+# cbSize value for SP_DEVICE_INTERFACE_DETAIL_DATA_W.
+# The struct contains DWORD cbSize (4 bytes) + WCHAR DevicePath[1] (2 bytes).
+# MSVC pads the struct to the largest-member alignment (DWORD = 4 bytes),
+# making the total sizeof() = 8 on both 32- and 64-bit Windows.
+_DETAIL_DATA_CBSIZE: int = 8
+
+
 if _WINDOWS:
     from ctypes import windll, wintypes
-
-    # -----------------------------------------------------------------------
-    # Constants
-    # -----------------------------------------------------------------------
-
-    # GUID for the EMI device interface: {45BD8344-7ED6-49CF-A440-C276C933B053}
-    _EMI_GUID_DATA1: int = 0x45BD8344
-    _EMI_GUID_DATA2: int = 0x7ED6
-    _EMI_GUID_DATA3: int = 0x49CF
-    _EMI_GUID_DATA4: tuple[int, ...] = (0xA4, 0x40, 0xC2, 0x76, 0xC9, 0x33, 0xB0, 0x53)
-
-    # IOCTLs — CTL_CODE(FILE_DEVICE_UNKNOWN=0x22, func, METHOD_BUFFERED=0, FILE_READ_ACCESS=1)
-    # = (0x22 << 16) | (1 << 14) | (func << 2) | 0
-    _IOCTL_EMI_GET_VERSION: int = 0x00224000  # func = 0
-    _IOCTL_EMI_GET_METADATA_SIZE: int = 0x00224004  # func = 1
-    _IOCTL_EMI_GET_METADATA: int = 0x00224008  # func = 2
-    _IOCTL_EMI_GET_MEASUREMENT: int = 0x0022400C  # func = 3
-
-    _EMI_VERSION_V1: int = 1
-    _EMI_VERSION_V2: int = 2
-
-    # EMI_NAME_MAX: maximum WCHAR count for OEM/Model fields in metadata (= 16 WCHARs = 32 bytes)
-    _EMI_NAME_MAX: int = 16
-
-    # EmiMeasurementUnitPicowattHours = 0
-    _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS: int = 0
-
-    # 1 picowatt-hour = 1e-12 W * 3600 s = 3.6e-9 J = 3.6e-6 mJ
-    _PICOWATT_HOURS_TO_MILLIJOULES: float = 3.6e-6
-
-    _GENERIC_READ: int = 0x80000000
-    _FILE_SHARE_READ: int = 0x00000001
-    _OPEN_EXISTING: int = 3
-    # INVALID_HANDLE_VALUE: all bits set, platform-width.
-    # Using bit arithmetic avoids the Optional[int] return type of ctypes.c_void_p.value.
-    _INVALID_HANDLE_VALUE: int = 2 ** (ctypes.sizeof(ctypes.c_void_p) * 8) - 1
-    _DIGCF_PRESENT: int = 0x00000002
-    _DIGCF_DEVICEINTERFACE: int = 0x00000010
-
-    # cbSize value for SP_DEVICE_INTERFACE_DETAIL_DATA_W.
-    # The struct contains DWORD cbSize (4 bytes) + WCHAR DevicePath[1] (2 bytes).
-    # MSVC pads the struct to the largest-member alignment (DWORD = 4 bytes),
-    # making the total sizeof() = 8 on both 32- and 64-bit Windows.
-    _DETAIL_DATA_CBSIZE: int = 8
 
     # -----------------------------------------------------------------------
     # ctypes structures
@@ -119,11 +126,47 @@ if _WINDOWS:
         wintypes.DWORD,
     ]
     _setupapi.SetupDiEnumDeviceInterfaces.restype = wintypes.BOOL
+    _setupapi.SetupDiEnumDeviceInterfaces.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(_Guid),
+        wintypes.DWORD,
+        ctypes.POINTER(_SpDeviceInterfaceData),
+    ]
     _setupapi.SetupDiGetDeviceInterfaceDetailW.restype = wintypes.BOOL
+    _setupapi.SetupDiGetDeviceInterfaceDetailW.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(_SpDeviceInterfaceData),
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.c_void_p,
+    ]
     _setupapi.SetupDiDestroyDeviceInfoList.restype = wintypes.BOOL
+    _setupapi.SetupDiDestroyDeviceInfoList.argtypes = [ctypes.c_void_p]
     _kernel32.CreateFileW.restype = ctypes.c_void_p
+    _kernel32.CreateFileW.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+    ]
     _kernel32.DeviceIoControl.restype = wintypes.BOOL
+    _kernel32.DeviceIoControl.argtypes = [
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.c_void_p,
+    ]
     _kernel32.CloseHandle.restype = wintypes.BOOL
+    _kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
 
 
 # -----------------------------------------------------------------------
@@ -394,8 +437,13 @@ class EMIFile:
             offset = _oem_size + _model_size + 4  # skip OEM, Model, Revision, ChannelCount
 
             for i in range(channel_count):
+                # Stop if the buffer is truncated rather than reading past its end.
+                if offset + 6 > len(raw):
+                    break
                 unit = int.from_bytes(raw[offset : offset + 4], "little")
                 name_size = int.from_bytes(raw[offset + 4 : offset + 6], "little")
+                if offset + 6 + name_size > len(raw):
+                    break
                 name = (
                     raw[offset + 6 : offset + 6 + name_size].decode("utf-16-le").rstrip("\x00") if name_size > 0 else ""
                 )
@@ -410,14 +458,19 @@ class EMIFile:
                 offset += 4 + 2 + name_size
 
         elif version == _EMI_VERSION_V1:
-            # Single channel: the whole device is one domain.
-            unit = int.from_bytes(raw[0:4], "little")
             _oem_size = _EMI_NAME_MAX * 2
             _model_size = _EMI_NAME_MAX * 2
+            header_size = 4 + _oem_size + _model_size + 4  # unit, OEM, Model, revision, name size
+            if len(raw) < header_size:
+                raise ZeusEMIInitError(f"EMI V1 metadata is too short ({len(raw)} bytes).")
+            # Single channel: the whole device is one domain.
+            unit = int.from_bytes(raw[0:4], "little")
             name_size = int.from_bytes(
                 raw[4 + _oem_size + _model_size + 2 : 4 + _oem_size + _model_size + 4],
                 "little",
             )
+            if len(raw) < header_size + name_size:
+                raise ZeusEMIInitError(f"EMI V1 metadata is truncated for the channel name ({len(raw)} bytes).")
             name = (
                 raw[4 + _oem_size + _model_size + 4 : 4 + _oem_size + _model_size + 4 + name_size]
                 .decode("utf-16-le")
@@ -455,16 +508,27 @@ class EMIFile:
         # EMI_MEASUREMENT_DATA_V2: ChannelData[ChannelCount]
         # Each EMI_CHANNEL_MEASUREMENT_DATA: AbsoluteEnergy (8 bytes) + AbsoluteTime (8 bytes)
         offset = channel_index * 16
+        if len(meas_bytes) < offset + 8:
+            raise ZeusEMIInitError(
+                f"Measurement data from '{self.path}' is too short "
+                f"({len(meas_bytes)} bytes, expected at least {offset + 8})."
+            )
         energy_pwh = int.from_bytes(meas_bytes[offset : offset + 8], "little")
         return energy_pwh * _PICOWATT_HOURS_TO_MILLIJOULES
 
     def __del__(self) -> None:
-        """Close the device handle."""
-        if not _WINDOWS:
+        """Close the device handle.
+
+        During interpreter shutdown module globals may already be cleared, so we
+        guard against ``_kernel32``/``ctypes`` being ``None`` and swallow any
+        error rather than raising from a finalizer.
+        """
+        if not _WINDOWS or _kernel32 is None or ctypes is None:
             return
         handle = getattr(self, "_handle", 0)
         if isinstance(handle, int) and handle and handle != _INVALID_HANDLE_VALUE:
-            _kernel32.CloseHandle(ctypes.c_void_p(handle))
+            with contextlib.suppress(Exception):
+                _kernel32.CloseHandle(ctypes.c_void_p(handle))
             self._handle = 0
 
 

--- a/zeus/device/cpu/emi.py
+++ b/zeus/device/cpu/emi.py
@@ -1,0 +1,631 @@
+"""Windows EMI (Energy Meter Interface) CPU energy monitoring.
+
+- EMI (Energy Meter Interface):
+   EMI is a Windows interface introduced in Windows 10 that allows applications to read energy
+   consumption data from hardware energy meters. It provides access to RAPL (Running Average Power
+   Limit) counters on Intel processors via a standardized IOCTL interface.
+
+- Energy Meter Device:
+   An EMI device represents one energy metering unit. On Intel systems, a single EMI device
+   typically exposes multiple channels corresponding to different power domains (e.g., package,
+   DRAM, PP0, PP1) for each CPU socket.
+
+- Channel:
+   Each EMI device exposes one or more named channels. Channel names follow the pattern
+   ``RAPL_Package{N}_{DOMAIN}`` where N is the socket index and DOMAIN is the power domain
+   (e.g., PKG, DRAM, PP0, PP1).
+
+See: https://learn.microsoft.com/en-us/windows-hardware/drivers/powermeter/energy-meter-interface
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes
+import logging
+import re
+import sys
+from functools import lru_cache
+from typing import Sequence
+
+import zeus.device.cpu.common as cpu_common
+from zeus.device.cpu.common import CpuDramMeasurement
+from zeus.device.exception import ZeusBaseCPUError
+
+logger = logging.getLogger(__name__)
+
+# EMI is a Windows-only interface. windll/wintypes are only available on Windows.
+_WINDOWS = sys.platform == "win32"
+
+if _WINDOWS:
+    from ctypes import windll, wintypes
+
+    # -----------------------------------------------------------------------
+    # Constants
+    # -----------------------------------------------------------------------
+
+    # GUID for the EMI device interface: {45BD8344-7ED6-49CF-A440-C276C933B053}
+    _EMI_GUID_DATA1: int = 0x45BD8344
+    _EMI_GUID_DATA2: int = 0x7ED6
+    _EMI_GUID_DATA3: int = 0x49CF
+    _EMI_GUID_DATA4: tuple[int, ...] = (0xA4, 0x40, 0xC2, 0x76, 0xC9, 0x33, 0xB0, 0x53)
+
+    # IOCTLs — CTL_CODE(FILE_DEVICE_UNKNOWN=0x22, func, METHOD_BUFFERED=0, FILE_READ_ACCESS=1)
+    # = (0x22 << 16) | (1 << 14) | (func << 2) | 0
+    _IOCTL_EMI_GET_VERSION: int = 0x00224000  # func = 0
+    _IOCTL_EMI_GET_METADATA_SIZE: int = 0x00224004  # func = 1
+    _IOCTL_EMI_GET_METADATA: int = 0x00224008  # func = 2
+    _IOCTL_EMI_GET_MEASUREMENT: int = 0x0022400C  # func = 3
+
+    _EMI_VERSION_V1: int = 1
+    _EMI_VERSION_V2: int = 2
+
+    # EMI_NAME_MAX: maximum WCHAR count for OEM/Model fields in metadata (= 16 WCHARs = 32 bytes)
+    _EMI_NAME_MAX: int = 16
+
+    # EmiMeasurementUnitPicowattHours = 0
+    _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS: int = 0
+
+    # 1 picowatt-hour = 1e-12 W * 3600 s = 3.6e-9 J = 3.6e-6 mJ
+    _PICOWATT_HOURS_TO_MILLIJOULES: float = 3.6e-6
+
+    _GENERIC_READ: int = 0x80000000
+    _FILE_SHARE_READ: int = 0x00000001
+    _OPEN_EXISTING: int = 3
+    # INVALID_HANDLE_VALUE: all bits set, platform-width.
+    # Using bit arithmetic avoids the Optional[int] return type of ctypes.c_void_p.value.
+    _INVALID_HANDLE_VALUE: int = 2 ** (ctypes.sizeof(ctypes.c_void_p) * 8) - 1
+    _DIGCF_PRESENT: int = 0x00000002
+    _DIGCF_DEVICEINTERFACE: int = 0x00000010
+
+    # cbSize value for SP_DEVICE_INTERFACE_DETAIL_DATA_W.
+    # The struct contains DWORD cbSize (4 bytes) + WCHAR DevicePath[1] (2 bytes).
+    # MSVC pads the struct to the largest-member alignment (DWORD = 4 bytes),
+    # making the total sizeof() = 8 on both 32- and 64-bit Windows.
+    _DETAIL_DATA_CBSIZE: int = 8
+
+    # -----------------------------------------------------------------------
+    # ctypes structures
+    # -----------------------------------------------------------------------
+
+    class _Guid(ctypes.Structure):  # noqa: N801 (Windows API name)
+        _fields_ = [
+            ("Data1", wintypes.DWORD),
+            ("Data2", wintypes.WORD),
+            ("Data3", wintypes.WORD),
+            ("Data4", ctypes.c_ubyte * 8),
+        ]
+
+    class _SpDeviceInterfaceData(ctypes.Structure):  # noqa: N801 (Windows API name)
+        _fields_ = [
+            ("cbSize", wintypes.DWORD),
+            ("InterfaceClassGuid", _Guid),
+            ("Flags", wintypes.DWORD),
+            ("Reserved", ctypes.c_size_t),
+        ]
+
+    # -----------------------------------------------------------------------
+    # Windows API setup
+    # -----------------------------------------------------------------------
+
+    _setupapi = windll.setupapi
+    _kernel32 = windll.kernel32
+
+    _setupapi.SetupDiGetClassDevsW.restype = ctypes.c_void_p
+    _setupapi.SetupDiGetClassDevsW.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_wchar_p,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+    ]
+    _setupapi.SetupDiEnumDeviceInterfaces.restype = wintypes.BOOL
+    _setupapi.SetupDiGetDeviceInterfaceDetailW.restype = wintypes.BOOL
+    _setupapi.SetupDiDestroyDeviceInfoList.restype = wintypes.BOOL
+    _kernel32.CreateFileW.restype = ctypes.c_void_p
+    _kernel32.DeviceIoControl.restype = wintypes.BOOL
+    _kernel32.CloseHandle.restype = wintypes.BOOL
+
+
+# -----------------------------------------------------------------------
+# Exception classes
+# -----------------------------------------------------------------------
+
+
+class ZeusEMINotSupportedError(ZeusBaseCPUError):
+    """Raised when EMI is not available on this system."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+class ZeusEMIInitError(ZeusBaseCPUError):
+    """Raised when an EMI device cannot be opened or queried."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+# -----------------------------------------------------------------------
+# Internal helpers (Windows-only)
+# -----------------------------------------------------------------------
+
+
+def _build_emi_guid() -> "_Guid":
+    """Build the EMI device interface GUID structure."""
+    guid = _Guid()
+    guid.Data1 = _EMI_GUID_DATA1
+    guid.Data2 = _EMI_GUID_DATA2
+    guid.Data3 = _EMI_GUID_DATA3
+    for i, byte in enumerate(_EMI_GUID_DATA4):
+        guid.Data4[i] = byte
+    return guid
+
+
+def _get_emi_device_paths() -> list[str]:
+    """Enumerate all EMI-compliant device interface paths on this Windows system.
+
+    Returns an empty list if no devices are found or if not running on Windows.
+    """
+    guid = _build_emi_guid()
+
+    hdev = _setupapi.SetupDiGetClassDevsW(
+        ctypes.byref(guid),
+        None,
+        None,
+        _DIGCF_PRESENT | _DIGCF_DEVICEINTERFACE,
+    )
+    if hdev == _INVALID_HANDLE_VALUE:
+        logger.debug("SetupDiGetClassDevsW returned INVALID_HANDLE_VALUE for EMI GUID.")
+        return []
+
+    paths: list[str] = []
+    try:
+        index = 0
+        while True:
+            iface = _SpDeviceInterfaceData()
+            iface.cbSize = ctypes.sizeof(_SpDeviceInterfaceData)
+            if not _setupapi.SetupDiEnumDeviceInterfaces(
+                ctypes.c_void_p(hdev),
+                None,
+                ctypes.byref(guid),
+                index,
+                ctypes.byref(iface),
+            ):
+                break
+
+            # First call: obtain required buffer size.
+            required = wintypes.DWORD(0)
+            _setupapi.SetupDiGetDeviceInterfaceDetailW(
+                ctypes.c_void_p(hdev),
+                ctypes.byref(iface),
+                None,
+                0,
+                ctypes.byref(required),
+                None,
+            )
+            if required.value == 0:
+                index += 1
+                continue
+
+            # Second call: fill the detail buffer.
+            # SP_DEVICE_INTERFACE_DETAIL_DATA_W layout:
+            #   DWORD cbSize  (4 bytes)
+            #   WCHAR DevicePath[ANYSIZE_ARRAY]  (variable)
+            detail_buf = ctypes.create_string_buffer(required.value)
+            ctypes.cast(detail_buf, ctypes.POINTER(wintypes.DWORD))[0] = _DETAIL_DATA_CBSIZE
+            if _setupapi.SetupDiGetDeviceInterfaceDetailW(
+                ctypes.c_void_p(hdev),
+                ctypes.byref(iface),
+                detail_buf,
+                required,
+                None,
+                None,
+            ):
+                # DevicePath starts immediately after the DWORD cbSize field.
+                path = ctypes.wstring_at(ctypes.addressof(detail_buf) + 4)
+                paths.append(path)
+                logger.debug("Found EMI device: %s", path)
+
+            index += 1
+    finally:
+        _setupapi.SetupDiDestroyDeviceInfoList(ctypes.c_void_p(hdev))
+
+    return paths
+
+
+def _ioctl(handle: "ctypes.c_void_p", code: int, out_size: int) -> bytes | None:
+    """Send a buffered IOCTL with no input buffer and return the output bytes.
+
+    Returns ``None`` if the call fails.
+    """
+    buf = ctypes.create_string_buffer(out_size)
+    bytes_returned = wintypes.DWORD(0)
+    ok = _kernel32.DeviceIoControl(
+        handle,
+        code,
+        None,
+        0,
+        buf,
+        out_size,
+        ctypes.byref(bytes_returned),
+        None,
+    )
+    if not ok:
+        return None
+    return bytes(buf)[: bytes_returned.value]
+
+
+# -----------------------------------------------------------------------
+# Channel metadata dataclass (plain class to keep it lightweight)
+# -----------------------------------------------------------------------
+
+
+class _EMIChannel:
+    """Metadata for a single EMI channel."""
+
+    __slots__ = ("index", "name", "unit")
+
+    def __init__(self, index: int, name: str, unit: int) -> None:
+        self.index = index
+        self.name = name
+        self.unit = unit
+
+
+# -----------------------------------------------------------------------
+# EMIFile — manages one open EMI device handle
+# -----------------------------------------------------------------------
+
+
+class EMIFile:
+    """Manages an open Windows EMI device handle and reads energy data from it.
+
+    Each ``EMIFile`` corresponds to one EMI device interface (one device path).
+    It reads energy values in picowatt-hours and converts them to millijoules.
+
+    Attributes:
+        path (str): The Windows device interface path.
+        version (int): The EMI interface version reported by the device (1 or 2).
+        channels (list[_EMIChannel]): Metadata for each channel on this device.
+    """
+
+    def __init__(self, path: str) -> None:
+        r"""Open the EMI device and read its metadata.
+
+        Args:
+            path: Windows device interface path (e.g. ``\\?\acpi#...``).
+
+        Raises:
+            ZeusEMIInitError: If the device cannot be opened or its metadata cannot be read.
+        """
+        self.path = path
+
+        handle = _kernel32.CreateFileW(
+            path,
+            _GENERIC_READ,
+            _FILE_SHARE_READ,
+            None,
+            _OPEN_EXISTING,
+            0,
+            None,
+        )
+        if handle == _INVALID_HANDLE_VALUE:
+            err = _kernel32.GetLastError()
+            raise ZeusEMIInitError(f"Failed to open EMI device '{path}' (Windows error {err}).")
+        # Store the raw integer handle value so that __del__ can safely check
+        # ``isinstance(self._handle, int)`` and avoid calling CloseHandle on
+        # mocked handles during testing.
+        self._handle: int = int(handle)
+
+        try:
+            self.version, self.channels = self._read_metadata()
+        except ZeusEMIInitError:
+            _kernel32.CloseHandle(self._handle)
+            raise
+
+    def _read_metadata(self) -> tuple[int, list[_EMIChannel]]:
+        """Query the device for its version and channel metadata.
+
+        Returns:
+            A (version, channels) tuple.
+
+        Raises:
+            ZeusEMIInitError: On any IOCTL failure.
+        """
+        # Version
+        ver_bytes = _ioctl(ctypes.c_void_p(self._handle), _IOCTL_EMI_GET_VERSION, 2)
+        if ver_bytes is None or len(ver_bytes) < 2:
+            raise ZeusEMIInitError(f"IOCTL_EMI_GET_VERSION failed for '{self.path}'.")
+        version = int.from_bytes(ver_bytes[:2], "little")
+        if version not in (_EMI_VERSION_V1, _EMI_VERSION_V2):
+            raise ZeusEMIInitError(f"Unsupported EMI version {version} for '{self.path}'.")
+
+        # Metadata size
+        ms_bytes = _ioctl(ctypes.c_void_p(self._handle), _IOCTL_EMI_GET_METADATA_SIZE, 4)
+        if ms_bytes is None or len(ms_bytes) < 4:
+            raise ZeusEMIInitError(f"IOCTL_EMI_GET_METADATA_SIZE failed for '{self.path}'.")
+        meta_size = int.from_bytes(ms_bytes[:4], "little")
+        if meta_size == 0:
+            raise ZeusEMIInitError(f"EMI device '{self.path}' reported zero metadata size.")
+
+        # Metadata payload
+        meta_bytes = _ioctl(ctypes.c_void_p(self._handle), _IOCTL_EMI_GET_METADATA, meta_size)
+        if meta_bytes is None:
+            raise ZeusEMIInitError(f"IOCTL_EMI_GET_METADATA failed for '{self.path}'.")
+
+        channels = self._parse_channels(version, meta_bytes)
+        return version, channels
+
+    @staticmethod
+    def _parse_channels(version: int, raw: bytes) -> list[_EMIChannel]:
+        """Parse channel metadata from the raw metadata buffer.
+
+        EMI_METADATA_V1 layout (offsets in bytes):
+            MeasurementUnit  UINT   4
+            HardwareOEM      WCHAR[16]  32
+            HardwareModel    WCHAR[16]  32
+            HardwareRevision USHORT 2
+            MeteredHardwareNameSize USHORT 2
+            MeteredHardwareName WCHAR[] variable
+
+        EMI_METADATA_V2 layout (offsets in bytes):
+            HardwareOEM      WCHAR[16]  32   @ 0
+            HardwareModel    WCHAR[16]  32   @ 32
+            HardwareRevision USHORT     2    @ 64
+            ChannelCount     USHORT     2    @ 66
+            Channels[]                       @ 68
+
+        Each EMI_CHANNEL_V2:
+            MeasurementUnit  UINT   4
+            ChannelNameSize  USHORT 2   (bytes, including null terminator)
+            ChannelName      WCHAR[] ChannelNameSize bytes
+        """
+        channels: list[_EMIChannel] = []
+
+        if version == _EMI_VERSION_V2:
+            # _EMI_NAME_MAX = 16 WCHARs = 32 bytes each for OEM and Model.
+            _oem_size = _EMI_NAME_MAX * 2
+            _model_size = _EMI_NAME_MAX * 2
+            channel_count = int.from_bytes(
+                raw[_oem_size + _model_size + 2 : _oem_size + _model_size + 4],
+                "little",
+            )
+            offset = _oem_size + _model_size + 4  # skip OEM, Model, Revision, ChannelCount
+
+            for i in range(channel_count):
+                unit = int.from_bytes(raw[offset : offset + 4], "little")
+                name_size = int.from_bytes(raw[offset + 4 : offset + 6], "little")
+                name = (
+                    raw[offset + 6 : offset + 6 + name_size].decode("utf-16-le").rstrip("\x00") if name_size > 0 else ""
+                )
+                if unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
+                    logger.warning(
+                        "EMI channel %d ('%s') uses unexpected unit %d; expected picowatt-hours (0).",
+                        i,
+                        name,
+                        unit,
+                    )
+                channels.append(_EMIChannel(index=i, name=name, unit=unit))
+                offset += 4 + 2 + name_size
+
+        elif version == _EMI_VERSION_V1:
+            # Single channel: the whole device is one domain.
+            unit = int.from_bytes(raw[0:4], "little")
+            _oem_size = _EMI_NAME_MAX * 2
+            _model_size = _EMI_NAME_MAX * 2
+            name_size = int.from_bytes(
+                raw[4 + _oem_size + _model_size + 2 : 4 + _oem_size + _model_size + 4],
+                "little",
+            )
+            name = (
+                raw[4 + _oem_size + _model_size + 4 : 4 + _oem_size + _model_size + 4 + name_size]
+                .decode("utf-16-le")
+                .rstrip("\x00")
+                if name_size > 0
+                else "EMI_V1"
+            )
+            if unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
+                logger.warning(
+                    "EMI V1 channel ('%s') uses unexpected unit %d; expected picowatt-hours (0).",
+                    name,
+                    unit,
+                )
+            channels.append(_EMIChannel(index=0, name=name, unit=unit))
+
+        return channels
+
+    def read(self, channel_index: int) -> float:
+        """Read the accumulated energy for the given channel.
+
+        Args:
+            channel_index: Zero-based index of the channel within this device.
+
+        Returns:
+            The accumulated energy in millijoules.
+
+        Raises:
+            ZeusEMIInitError: If the IOCTL call fails.
+        """
+        meas_size = len(self.channels) * 16  # 16 bytes per EMI_CHANNEL_MEASUREMENT_DATA
+        meas_bytes = _ioctl(ctypes.c_void_p(self._handle), _IOCTL_EMI_GET_MEASUREMENT, meas_size)
+        if meas_bytes is None:
+            err = _kernel32.GetLastError()
+            raise ZeusEMIInitError(f"IOCTL_EMI_GET_MEASUREMENT failed for '{self.path}' (Windows error {err}).")
+        # EMI_MEASUREMENT_DATA_V2: ChannelData[ChannelCount]
+        # Each EMI_CHANNEL_MEASUREMENT_DATA: AbsoluteEnergy (8 bytes) + AbsoluteTime (8 bytes)
+        offset = channel_index * 16
+        energy_pwh = int.from_bytes(meas_bytes[offset : offset + 8], "little")
+        return energy_pwh * _PICOWATT_HOURS_TO_MILLIJOULES
+
+    def __del__(self) -> None:
+        """Close the device handle."""
+        if not _WINDOWS:
+            return
+        handle = getattr(self, "_handle", 0)
+        if isinstance(handle, int) and handle and handle != _INVALID_HANDLE_VALUE:
+            _kernel32.CloseHandle(ctypes.c_void_p(handle))
+            self._handle = 0
+
+
+# -----------------------------------------------------------------------
+# EMICPU — one CPU package
+# -----------------------------------------------------------------------
+
+
+class EMICPU(cpu_common.CPU):
+    """Reads energy for a single Intel CPU package via the Windows EMI interface.
+
+    Attributes:
+        cpu_index (int): Zero-based package (socket) index.
+    """
+
+    def __init__(
+        self,
+        cpu_index: int,
+        emi_file: EMIFile,
+        pkg_channel_index: int,
+        dram_channel_index: int | None,
+    ) -> None:
+        """Initialize the EMICPU.
+
+        Args:
+            cpu_index: Zero-based CPU package (socket) index.
+            emi_file: The :class:`EMIFile` that owns the device handle.
+            pkg_channel_index: Index of the PKG (package) energy channel in ``emi_file``.
+            dram_channel_index: Index of the DRAM energy channel, or ``None`` if unavailable.
+        """
+        super().__init__(cpu_index)
+        self._emi_file = emi_file
+        self._pkg_channel_index = pkg_channel_index
+        self._dram_channel_index = dram_channel_index
+
+    def get_total_energy_consumption(self) -> CpuDramMeasurement:
+        """Return the total accumulated energy for this CPU package. Units: mJ."""
+        cpu_mj = self._emi_file.read(self._pkg_channel_index)
+        dram_mj: float | None = None
+        if self._dram_channel_index is not None:
+            dram_mj = self._emi_file.read(self._dram_channel_index)
+        return CpuDramMeasurement(cpu_mj=cpu_mj, dram_mj=dram_mj)
+
+    def supports_get_dram_energy_consumption(self) -> bool:
+        """Return ``True`` if DRAM energy data is available for this package."""
+        return self._dram_channel_index is not None
+
+
+# -----------------------------------------------------------------------
+# EMICPUs — manager for all packages
+# -----------------------------------------------------------------------
+
+
+class EMICPUs(cpu_common.CPUs):
+    """Manages all Intel CPU packages accessible via the Windows EMI interface.
+
+    Each detected ``RAPL_Package{N}_PKG`` EMI channel maps to one
+    :class:`EMICPU` object at index N.
+    """
+
+    def __init__(self) -> None:
+        """Discover and initialise all EMI CPU objects.
+
+        Raises:
+            ZeusEMINotSupportedError: If EMI is unavailable on this system.
+            ZeusEMIInitError: If device metadata cannot be queried.
+        """
+        if not emi_is_available():
+            raise ZeusEMINotSupportedError("No EMI-compatible energy meter devices were found on this system.")
+        self._cpus: list[EMICPU] = []
+        self._init_cpus()
+
+    def _init_cpus(self) -> None:
+        """Build the list of :class:`EMICPU` objects from all EMI devices."""
+        paths = _get_emi_device_paths()
+
+        # pkg_index → (EMIFile, pkg_channel_idx, dram_channel_idx | None)
+        packages: dict[int, tuple[EMIFile, int, int | None]] = {}
+
+        # Pattern: RAPL_Package{N}_PKG  or  RAPL_Package{N}_DRAM
+        _pkg_re = re.compile(r"RAPL_Package(\d+)_PKG$", re.IGNORECASE)
+        _dram_re = re.compile(r"RAPL_Package(\d+)_DRAM$", re.IGNORECASE)
+
+        for path in paths:
+            try:
+                emi_file = EMIFile(path)
+            except ZeusEMIInitError as err:
+                logger.warning("Skipping EMI device '%s': %s", path, err)
+                continue
+
+            # Locate PKG and DRAM channels for each package on this device.
+            pkg_channels: dict[int, int] = {}
+            dram_channels: dict[int, int] = {}
+            for ch in emi_file.channels:
+                m = _pkg_re.match(ch.name)
+                if m:
+                    pkg_channels[int(m.group(1))] = ch.index
+                    continue
+                m = _dram_re.match(ch.name)
+                if m:
+                    dram_channels[int(m.group(1))] = ch.index
+
+            for pkg_num, pkg_idx in pkg_channels.items():
+                dram_idx = dram_channels.get(pkg_num)
+                packages[pkg_num] = (emi_file, pkg_idx, dram_idx)
+
+        if not packages:
+            raise ZeusEMINotSupportedError("EMI devices were found but no RAPL_Package PKG channels were detected.")
+
+        for pkg_num in sorted(packages):
+            emi_file, pkg_idx, dram_idx = packages[pkg_num]
+            self._cpus.append(
+                EMICPU(
+                    cpu_index=pkg_num,
+                    emi_file=emi_file,
+                    pkg_channel_index=pkg_idx,
+                    dram_channel_index=dram_idx,
+                )
+            )
+            logger.info(
+                "Initialized EMI CPU %d: PKG channel=%d, DRAM channel=%s",
+                pkg_num,
+                pkg_idx,
+                dram_idx,
+            )
+
+    @property
+    def cpus(self) -> Sequence[EMICPU]:
+        """Return the list of :class:`EMICPU` objects."""
+        return self._cpus
+
+    def __del__(self) -> None:
+        """Clean up resources."""
+        pass
+
+
+# -----------------------------------------------------------------------
+# Availability check
+# -----------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def emi_is_available() -> bool:
+    """Return ``True`` if at least one EMI energy meter device is present.
+
+    This function is cached — the check runs at most once per process.
+    On non-Windows platforms it always returns ``False``.
+    """
+    if not _WINDOWS:
+        logger.info("EMI is not supported on non-Windows platforms.")
+        return False
+    try:
+        paths = _get_emi_device_paths()
+    except Exception as err:
+        logger.info("EMI device enumeration failed: %s", err)
+        return False
+    if paths:
+        logger.info(
+            "EMI is available: found %d device(s).",
+            len(paths),
+        )
+        return True
+    logger.info("No EMI energy meter devices found.")
+    return False

--- a/zeus/device/cpu/emi.py
+++ b/zeus/device/cpu/emi.py
@@ -43,14 +43,10 @@ _WINDOWS = sys.platform == "win32"
 _PKG_CHANNEL_RE = re.compile(r"RAPL_Package(\d+)_PKG$", re.IGNORECASE)
 _DRAM_CHANNEL_RE = re.compile(r"RAPL_Package(\d+)_DRAM$", re.IGNORECASE)
 
-# -----------------------------------------------------------------------
-# Constants
-#
-# These are plain integer/float values that do not depend on the Windows-only
-# ``windll``/``wintypes`` imports, so they are defined unconditionally. This lets
-# the platform-independent helpers (metadata parsing, energy conversion) run and
-# be unit tested on any OS, not just Windows.
-# -----------------------------------------------------------------------
+# The constants below are plain integer/float values that do not depend on the
+# Windows-only imports, so they are defined unconditionally. This lets the
+# platform-independent helpers (metadata parsing, energy conversion) run and be
+# unit tested on any OS, not just Windows.
 
 # GUID for the EMI device interface: {45BD8344-7ED6-49CF-A440-C276C933B053}
 _EMI_GUID_DATA1: int = 0x45BD8344
@@ -58,7 +54,7 @@ _EMI_GUID_DATA2: int = 0x7ED6
 _EMI_GUID_DATA3: int = 0x49CF
 _EMI_GUID_DATA4: tuple[int, ...] = (0xA4, 0x40, 0xC2, 0x76, 0xC9, 0x33, 0xB0, 0x53)
 
-# IOCTLs — CTL_CODE(FILE_DEVICE_UNKNOWN=0x22, func, METHOD_BUFFERED=0, FILE_READ_ACCESS=1)
+# IOCTLs: CTL_CODE(FILE_DEVICE_UNKNOWN=0x22, func, METHOD_BUFFERED=0, FILE_READ_ACCESS=1)
 # = (0x22 << 16) | (1 << 14) | (func << 2) | 0
 _IOCTL_EMI_GET_VERSION: int = 0x00224000  # func = 0
 _IOCTL_EMI_GET_METADATA_SIZE: int = 0x00224004  # func = 1
@@ -96,10 +92,6 @@ _DETAIL_DATA_CBSIZE: int = 8 if ctypes.sizeof(ctypes.c_void_p) == 8 else 6
 if _WINDOWS:
     from ctypes import WinDLL, get_last_error, wintypes
 
-    # -----------------------------------------------------------------------
-    # ctypes structures
-    # -----------------------------------------------------------------------
-
     class _Guid(ctypes.Structure):  # noqa: N801 (Windows API name)
         _fields_ = [
             ("Data1", wintypes.DWORD),
@@ -122,10 +114,6 @@ if _WINDOWS:
             ("Number", ctypes.c_ubyte),
             ("Reserved", ctypes.c_ubyte),
         ]
-
-    # -----------------------------------------------------------------------
-    # Windows API setup
-    # -----------------------------------------------------------------------
 
     # Private WinDLL instances with use_last_error=True so ctypes captures the
     # Win32 error code immediately after each call, retrievable via
@@ -193,11 +181,6 @@ if _WINDOWS:
     ]
 
 
-# -----------------------------------------------------------------------
-# Exception classes
-# -----------------------------------------------------------------------
-
-
 class ZeusEMINotSupportedError(ZeusBaseCPUError):
     """Raised when EMI is not available on this system."""
 
@@ -212,11 +195,6 @@ class ZeusEMIInitError(ZeusBaseCPUError):
     def __init__(self, message: str) -> None:
         """Initialize Zeus Exception."""
         super().__init__(message)
-
-
-# -----------------------------------------------------------------------
-# Internal helpers (Windows-only)
-# -----------------------------------------------------------------------
 
 
 def _build_emi_guid() -> "_Guid":
@@ -365,11 +343,6 @@ def _find_package_of_processor(raw: bytes, group: int, number: int, ptr_size: in
     return None
 
 
-# -----------------------------------------------------------------------
-# Channel metadata dataclass (plain class to keep it lightweight)
-# -----------------------------------------------------------------------
-
-
 class _EMIChannel:
     """Metadata for a single EMI channel."""
 
@@ -379,11 +352,6 @@ class _EMIChannel:
         self.index = index
         self.name = name
         self.unit = unit
-
-
-# -----------------------------------------------------------------------
-# EMIFile — manages one open EMI device handle
-# -----------------------------------------------------------------------
 
 
 class EMIFile:
@@ -600,11 +568,6 @@ class EMIFile:
             self._handle = 0
 
 
-# -----------------------------------------------------------------------
-# EMICPU — one CPU package
-# -----------------------------------------------------------------------
-
-
 class EMICPU(cpu_common.CPU):
     """Reads energy for a single Intel CPU package via the Windows EMI interface.
 
@@ -643,11 +606,6 @@ class EMICPU(cpu_common.CPU):
     def supports_get_dram_energy_consumption(self) -> bool:
         """Return ``True`` if DRAM energy data is available for this package."""
         return self._dram_channel_index is not None
-
-
-# -----------------------------------------------------------------------
-# EMICPUs — manager for all packages
-# -----------------------------------------------------------------------
 
 
 class EMICPUs(cpu_common.CPUs):
@@ -742,11 +700,6 @@ class EMICPUs(cpu_common.CPUs):
         pass
 
 
-# -----------------------------------------------------------------------
-# Availability check
-# -----------------------------------------------------------------------
-
-
 def get_current_emi_cpu_index() -> int:
     """Return the EMI CPU index of the package the calling thread is running on.
 
@@ -803,10 +756,6 @@ def emi_is_available() -> bool:
     A device only counts as usable if it exposes a RAPL-style package channel
     (`RAPL_Package{N}_PKG`), since EMI is also used for other kinds of energy
     meters (e.g., battery rails) that do not map to CPU packages.
-
-    This function never raises; any failure during probing is logged and
-    treated as EMI being unavailable. It is cached — the check runs at most
-    once per process. On non-Windows platforms it always returns ``False``.
     """
     if not _WINDOWS:
         logger.info("EMI is not supported on non-Windows platforms.")

--- a/zeus/device/cpu/emi.py
+++ b/zeus/device/cpu/emi.py
@@ -35,8 +35,13 @@ from zeus.device.exception import ZeusBaseCPUError
 
 logger = logging.getLogger(__name__)
 
-# EMI is a Windows-only interface. windll/wintypes are only available on Windows.
+# EMI is a Windows-only interface. WinDLL/wintypes are only usable on Windows.
 _WINDOWS = sys.platform == "win32"
+
+# Channel name patterns exposed by Intel RAPL-backed EMI devices:
+# RAPL_Package{N}_PKG and RAPL_Package{N}_DRAM.
+_PKG_CHANNEL_RE = re.compile(r"RAPL_Package(\d+)_PKG$", re.IGNORECASE)
+_DRAM_CHANNEL_RE = re.compile(r"RAPL_Package(\d+)_DRAM$", re.IGNORECASE)
 
 # -----------------------------------------------------------------------
 # Constants
@@ -81,15 +86,15 @@ _INVALID_HANDLE_VALUE: int = 2 ** (ctypes.sizeof(ctypes.c_void_p) * 8) - 1
 _DIGCF_PRESENT: int = 0x00000002
 _DIGCF_DEVICEINTERFACE: int = 0x00000010
 
-# cbSize value for SP_DEVICE_INTERFACE_DETAIL_DATA_W.
-# The struct contains DWORD cbSize (4 bytes) + WCHAR DevicePath[1] (2 bytes).
-# MSVC pads the struct to the largest-member alignment (DWORD = 4 bytes),
-# making the total sizeof() = 8 on both 32- and 64-bit Windows.
-_DETAIL_DATA_CBSIZE: int = 8
+# cbSize value for SP_DEVICE_INTERFACE_DETAIL_DATA_W (DWORD cbSize + WCHAR DevicePath[1]).
+# setupapi.h packs its structs with pack(8) on 64-bit Windows (sizeof = 8 after
+# padding) and pack(1) on 32-bit Windows (sizeof = 6), so the correct value
+# depends on the pointer width of the running Python interpreter.
+_DETAIL_DATA_CBSIZE: int = 8 if ctypes.sizeof(ctypes.c_void_p) == 8 else 6
 
 
 if _WINDOWS:
-    from ctypes import windll, wintypes
+    from ctypes import WinDLL, get_last_error, wintypes
 
     # -----------------------------------------------------------------------
     # ctypes structures
@@ -111,12 +116,23 @@ if _WINDOWS:
             ("Reserved", ctypes.c_size_t),
         ]
 
+    class _ProcessorNumber(ctypes.Structure):  # noqa: N801 (Windows PROCESSOR_NUMBER)
+        _fields_ = [
+            ("Group", wintypes.WORD),
+            ("Number", ctypes.c_ubyte),
+            ("Reserved", ctypes.c_ubyte),
+        ]
+
     # -----------------------------------------------------------------------
     # Windows API setup
     # -----------------------------------------------------------------------
 
-    _setupapi = windll.setupapi
-    _kernel32 = windll.kernel32
+    # Private WinDLL instances with use_last_error=True so ctypes captures the
+    # Win32 error code immediately after each call, retrievable via
+    # get_last_error(). Calling GetLastError() manually is unreliable because
+    # the interpreter may make its own Win32 calls in between.
+    _setupapi = WinDLL("setupapi", use_last_error=True)
+    _kernel32 = WinDLL("kernel32", use_last_error=True)
 
     _setupapi.SetupDiGetClassDevsW.restype = ctypes.c_void_p
     _setupapi.SetupDiGetClassDevsW.argtypes = [
@@ -167,6 +183,14 @@ if _WINDOWS:
     ]
     _kernel32.CloseHandle.restype = wintypes.BOOL
     _kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
+    _kernel32.GetCurrentProcessorNumberEx.restype = None
+    _kernel32.GetCurrentProcessorNumberEx.argtypes = [ctypes.POINTER(_ProcessorNumber)]
+    _kernel32.GetLogicalProcessorInformationEx.restype = wintypes.BOOL
+    _kernel32.GetLogicalProcessorInformationEx.argtypes = [
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
 
 
 # -----------------------------------------------------------------------
@@ -300,6 +324,47 @@ def _ioctl(handle: "ctypes.c_void_p", code: int, out_size: int) -> bytes | None:
     return bytes(buf)[: bytes_returned.value]
 
 
+def _find_package_of_processor(raw: bytes, group: int, number: int, ptr_size: int) -> int | None:
+    """Find the index of the processor package containing a logical processor.
+
+    Parses the SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX records returned by
+    `GetLogicalProcessorInformationEx` with `RelationProcessorPackage` and
+    returns the zero-based index of the package whose group affinity contains
+    the logical processor identified by processor group `group` and
+    within-group number `number`, or `None` if no package matches.
+
+    Record layout: DWORD Relationship, DWORD Size, then PROCESSOR_RELATIONSHIP
+    (BYTE Flags, BYTE EfficiencyClass, BYTE Reserved[20], WORD GroupCount,
+    GROUP_AFFINITY GroupMask[GroupCount]). Each GROUP_AFFINITY is a
+    pointer-sized KAFFINITY Mask, WORD Group, and WORD Reserved[3].
+
+    Raises:
+        ValueError: If the buffer is malformed.
+    """
+    group_affinity_size = ptr_size + 2 + 6  # Mask + Group + Reserved[3]
+    offset = 0
+    package_index = 0
+    while offset < len(raw):
+        if offset + 8 > len(raw):
+            raise ValueError("Truncated SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX record header.")
+        record_size = int.from_bytes(raw[offset + 4 : offset + 8], "little")
+        # 8-byte header + 24 bytes of PROCESSOR_RELATIONSHIP before the group array.
+        if record_size < 8 + 24 or offset + record_size > len(raw):
+            raise ValueError("Malformed SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX record size.")
+        group_count = int.from_bytes(raw[offset + 8 + 22 : offset + 8 + 24], "little")
+        for g in range(group_count):
+            ga_offset = offset + 8 + 24 + g * group_affinity_size
+            if ga_offset + group_affinity_size > offset + record_size:
+                raise ValueError("GROUP_AFFINITY entries extend past their record.")
+            mask = int.from_bytes(raw[ga_offset : ga_offset + ptr_size], "little")
+            ga_group = int.from_bytes(raw[ga_offset + ptr_size : ga_offset + ptr_size + 2], "little")
+            if ga_group == group and (mask >> number) & 1:
+                return package_index
+        package_index += 1
+        offset += record_size
+    return None
+
+
 # -----------------------------------------------------------------------
 # Channel metadata dataclass (plain class to keep it lightweight)
 # -----------------------------------------------------------------------
@@ -354,7 +419,7 @@ class EMIFile:
             None,
         )
         if handle == _INVALID_HANDLE_VALUE:
-            err = _kernel32.GetLastError()
+            err = get_last_error()
             raise ZeusEMIInitError(f"Failed to open EMI device '{path}' (Windows error {err}).")
         # Store the raw integer handle value so that __del__ can safely check
         # ``isinstance(self._handle, int)`` and avoid calling CloseHandle on
@@ -430,30 +495,28 @@ class EMIFile:
             # _EMI_NAME_MAX = 16 WCHARs = 32 bytes each for OEM and Model.
             _oem_size = _EMI_NAME_MAX * 2
             _model_size = _EMI_NAME_MAX * 2
-            channel_count = int.from_bytes(
-                raw[_oem_size + _model_size + 2 : _oem_size + _model_size + 4],
-                "little",
-            )
-            offset = _oem_size + _model_size + 4  # skip OEM, Model, Revision, ChannelCount
+            header_size = _oem_size + _model_size + 4  # OEM, Model, Revision, ChannelCount
+            if len(raw) < header_size:
+                raise ZeusEMIInitError(f"EMI V2 metadata is too short ({len(raw)} bytes).")
+            channel_count = int.from_bytes(raw[header_size - 2 : header_size], "little")
+            offset = header_size
 
             for i in range(channel_count):
-                # Stop if the buffer is truncated rather than reading past its end.
                 if offset + 6 > len(raw):
-                    break
+                    raise ZeusEMIInitError(
+                        f"EMI V2 metadata is truncated: expected {channel_count} channels, "
+                        f"but the buffer ({len(raw)} bytes) ends inside channel {i}."
+                    )
                 unit = int.from_bytes(raw[offset : offset + 4], "little")
                 name_size = int.from_bytes(raw[offset + 4 : offset + 6], "little")
                 if offset + 6 + name_size > len(raw):
-                    break
+                    raise ZeusEMIInitError(
+                        f"EMI V2 metadata is truncated: channel {i}'s name extends past "
+                        f"the end of the buffer ({len(raw)} bytes)."
+                    )
                 name = (
                     raw[offset + 6 : offset + 6 + name_size].decode("utf-16-le").rstrip("\x00") if name_size > 0 else ""
                 )
-                if unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
-                    logger.warning(
-                        "EMI channel %d ('%s') uses unexpected unit %d; expected picowatt-hours (0).",
-                        i,
-                        name,
-                        unit,
-                    )
                 channels.append(_EMIChannel(index=i, name=name, unit=unit))
                 offset += 4 + 2 + name_size
 
@@ -478,12 +541,6 @@ class EMIFile:
                 if name_size > 0
                 else "EMI_V1"
             )
-            if unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
-                logger.warning(
-                    "EMI V1 channel ('%s') uses unexpected unit %d; expected picowatt-hours (0).",
-                    name,
-                    unit,
-                )
             channels.append(_EMIChannel(index=0, name=name, unit=unit))
 
         return channels
@@ -498,12 +555,23 @@ class EMIFile:
             The accumulated energy in millijoules.
 
         Raises:
-            ZeusEMIInitError: If the IOCTL call fails.
+            ZeusEMIInitError: If the channel is invalid, the channel's measurement
+                unit is not picowatt-hours, or the IOCTL call fails.
         """
+        if not 0 <= channel_index < len(self.channels):
+            raise ZeusEMIInitError(
+                f"Channel index {channel_index} is out of range for '{self.path}' ({len(self.channels)} channels)."
+            )
+        channel = self.channels[channel_index]
+        if channel.unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
+            raise ZeusEMIInitError(
+                f"EMI channel '{channel.name}' reports measurement unit {channel.unit}, "
+                "not picowatt-hours (0); refusing to convert to millijoules."
+            )
         meas_size = len(self.channels) * 16  # 16 bytes per EMI_CHANNEL_MEASUREMENT_DATA
         meas_bytes = _ioctl(ctypes.c_void_p(self._handle), _IOCTL_EMI_GET_MEASUREMENT, meas_size)
         if meas_bytes is None:
-            err = _kernel32.GetLastError()
+            err = get_last_error()
             raise ZeusEMIInitError(f"IOCTL_EMI_GET_MEASUREMENT failed for '{self.path}' (Windows error {err}).")
         # EMI_MEASUREMENT_DATA_V2: ChannelData[ChannelCount]
         # Each EMI_CHANNEL_MEASUREMENT_DATA: AbsoluteEnergy (8 bytes) + AbsoluteTime (8 bytes)
@@ -597,7 +665,9 @@ class EMICPUs(cpu_common.CPUs):
             ZeusEMIInitError: If device metadata cannot be queried.
         """
         if not emi_is_available():
-            raise ZeusEMINotSupportedError("No EMI-compatible energy meter devices were found on this system.")
+            raise ZeusEMINotSupportedError(
+                "No EMI energy meter devices exposing RAPL package channels were found on this system."
+            )
         self._cpus: list[EMICPU] = []
         self._init_cpus()
 
@@ -608,10 +678,6 @@ class EMICPUs(cpu_common.CPUs):
         # pkg_index → (EMIFile, pkg_channel_idx, dram_channel_idx | None)
         packages: dict[int, tuple[EMIFile, int, int | None]] = {}
 
-        # Pattern: RAPL_Package{N}_PKG  or  RAPL_Package{N}_DRAM
-        _pkg_re = re.compile(r"RAPL_Package(\d+)_PKG$", re.IGNORECASE)
-        _dram_re = re.compile(r"RAPL_Package(\d+)_DRAM$", re.IGNORECASE)
-
         for path in paths:
             try:
                 emi_file = EMIFile(path)
@@ -620,16 +686,27 @@ class EMICPUs(cpu_common.CPUs):
                 continue
 
             # Locate PKG and DRAM channels for each package on this device.
+            # Channels with a non-picowatt-hour unit cannot be converted to
+            # millijoules, so they are excluded rather than misconverted.
             pkg_channels: dict[int, int] = {}
             dram_channels: dict[int, int] = {}
             for ch in emi_file.channels:
-                m = _pkg_re.match(ch.name)
-                if m:
-                    pkg_channels[int(m.group(1))] = ch.index
+                m = _PKG_CHANNEL_RE.match(ch.name)
+                target = pkg_channels
+                if m is None:
+                    m = _DRAM_CHANNEL_RE.match(ch.name)
+                    target = dram_channels
+                if m is None:
                     continue
-                m = _dram_re.match(ch.name)
-                if m:
-                    dram_channels[int(m.group(1))] = ch.index
+                if ch.unit != _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS:
+                    logger.warning(
+                        "Ignoring EMI channel '%s' on '%s': unexpected measurement unit %d (expected picowatt-hours).",
+                        ch.name,
+                        path,
+                        ch.unit,
+                    )
+                    continue
+                target[int(m.group(1))] = ch.index
 
             for pkg_num, pkg_idx in pkg_channels.items():
                 dram_idx = dram_channels.get(pkg_num)
@@ -670,12 +747,66 @@ class EMICPUs(cpu_common.CPUs):
 # -----------------------------------------------------------------------
 
 
+def get_current_emi_cpu_index() -> int:
+    """Return the EMI CPU index of the package the calling thread is running on.
+
+    This is the EMI counterpart of `get_current_rapl_zone_id` in the RAPL module:
+    the returned index can be passed as a `cpu_indices` entry to only measure the
+    CPU package the current thread is running on.
+
+    The current logical processor (processor group and within-group number) is
+    resolved with `GetCurrentProcessorNumberEx` and mapped to a package index
+    with `GetLogicalProcessorInformationEx`. Package records are assumed to be
+    enumerated in the same order as the EMI `RAPL_Package{N}` channel numbering.
+
+    !!! Note
+        The scheduler can migrate threads across packages at any time. To prevent
+        this from happening during monitoring, pin the process to specific CPUs
+        (e.g., with `SetProcessAffinityMask` or `start /affinity`).
+    """
+    if not _WINDOWS:
+        raise ZeusEMINotSupportedError("EMI is only supported on Windows.")
+
+    proc_number = _ProcessorNumber()
+    _kernel32.GetCurrentProcessorNumberEx(ctypes.byref(proc_number))
+
+    # RelationProcessorPackage (= 3) returns one record per physical CPU package.
+    relation_processor_package = 3
+    buf_size = wintypes.DWORD(0)
+    _kernel32.GetLogicalProcessorInformationEx(relation_processor_package, None, ctypes.byref(buf_size))
+    if buf_size.value == 0:
+        raise RuntimeError(
+            f"GetLogicalProcessorInformationEx did not report a buffer size (Windows error {get_last_error()})."
+        )
+    buf = ctypes.create_string_buffer(buf_size.value)
+    if not _kernel32.GetLogicalProcessorInformationEx(relation_processor_package, buf, ctypes.byref(buf_size)):
+        raise RuntimeError(f"GetLogicalProcessorInformationEx failed (Windows error {get_last_error()}).")
+
+    package_index = _find_package_of_processor(
+        bytes(buf)[: buf_size.value],
+        proc_number.Group,
+        proc_number.Number,
+        ctypes.sizeof(ctypes.c_void_p),
+    )
+    if package_index is None:
+        raise RuntimeError(
+            f"Could not map logical processor (group {proc_number.Group}, "
+            f"number {proc_number.Number}) to a CPU package."
+        )
+    return package_index
+
+
 @lru_cache(maxsize=1)
 def emi_is_available() -> bool:
-    """Return ``True`` if at least one EMI energy meter device is present.
+    """Return ``True`` if CPU energy can be measured through EMI on this system.
 
-    This function is cached — the check runs at most once per process.
-    On non-Windows platforms it always returns ``False``.
+    A device only counts as usable if it exposes a RAPL-style package channel
+    (`RAPL_Package{N}_PKG`), since EMI is also used for other kinds of energy
+    meters (e.g., battery rails) that do not map to CPU packages.
+
+    This function never raises; any failure during probing is logged and
+    treated as EMI being unavailable. It is cached — the check runs at most
+    once per process. On non-Windows platforms it always returns ``False``.
     """
     if not _WINDOWS:
         logger.info("EMI is not supported on non-Windows platforms.")
@@ -685,11 +816,24 @@ def emi_is_available() -> bool:
     except Exception as err:
         logger.info("EMI device enumeration failed: %s", err)
         return False
-    if paths:
-        logger.info(
-            "EMI is available: found %d device(s).",
-            len(paths),
-        )
-        return True
-    logger.info("No EMI energy meter devices found.")
+    if not paths:
+        logger.info("No EMI energy meter devices found.")
+        return False
+    for path in paths:
+        try:
+            emi_file = EMIFile(path)
+        except Exception as err:
+            logger.info("Cannot open EMI device '%s': %s", path, err)
+            continue
+        if any(
+            _PKG_CHANNEL_RE.match(ch.name) and ch.unit == _EMI_MEASUREMENT_UNIT_PICOWATT_HOURS
+            for ch in emi_file.channels
+        ):
+            logger.info("EMI is available: found a RAPL package channel on '%s'.", path)
+            return True
+    logger.info(
+        "Found %d EMI device(s), but none expose RAPL_Package PKG channels. "
+        "CPU energy measurement through EMI is unavailable.",
+        len(paths),
+    )
     return False

--- a/zeus/monitor/energy.py
+++ b/zeus/monitor/energy.py
@@ -201,10 +201,11 @@ class ZeusMonitor:
         except ZeusCPUNoPermissionError as err:
             if cpu_indices:
                 raise RuntimeError(
-                    "Root privilege is required to read RAPL metrics. See "
+                    "Permission error while initializing CPU energy monitoring. "
+                    "On Linux, RAPL requires root privileges; see "
                     "https://ml.energy/zeus/getting_started/#system-privileges "
-                    "for more information or disable CPU measurement by passing cpu_indices=[] to "
-                    "ZeusMonitor"
+                    "for more information. Alternatively, disable CPU measurement "
+                    "by passing cpu_indices=[] to ZeusMonitor."
                 ) from err
             self.cpus = EmptyCPUs()
 

--- a/zeus/show_env.py
+++ b/zeus/show_env.py
@@ -4,7 +4,8 @@
 - Package availability and versions: Zeus, PyTorch, JAX, CuPy.
 - NVIDIA GPU availability: Number of GPUs and models.
 - AMD GPU availability: Number of GPUs and models.
-- Intel RAPL availability: Number of CPUs and whether DRAM measurements are available.
+- Intel RAPL availability (Linux): Number of CPUs and whether DRAM measurements are available.
+- EMI availability (Windows): Number of CPUs and whether DRAM measurements are available.
 - Zeusd daemon connectivity and capabilities (when configured).
 """
 
@@ -18,12 +19,12 @@ import shutil
 import time
 
 import zeus
+from zeus.device.cpu.emi import EMICPU
 from zeus.device.cpu.rapl import RAPLCPU, ZeusdRAPLCPU
 from zeus.device.exception import ZeusBaseCPUError, ZeusBaseGPUError, ZeusBaseSoCError
 from zeus.utils.zeusd import ZeusdClient, ZeusdConfig
 from zeus.utils import framework
 from zeus.device import get_gpus, get_cpus, get_soc
-from zeus.device.cpu import RAPLCPUs
 from zeus.device.gpu.common import ZeusGPUInitError, EmptyGPUs
 from zeus.device.cpu.common import ZeusCPUInitError, EmptyCPUs
 from zeus.device.soc.common import ZeusSoCInitError, EmptySoC
@@ -128,7 +129,6 @@ def show_env():
         cpus = EmptyCPUs()
 
     if len(cpus) > 0:
-        assert isinstance(cpus, RAPLCPUs)
         for i, cpu in enumerate(cpus.cpus):
             if isinstance(cpu, ZeusdRAPLCPU):
                 cpu_availability += f"  CPU {i}:\n    CPU measurements available (Zeusd at {cpu._client.endpoint})\n"
@@ -142,6 +142,17 @@ def show_env():
                     dram = cpu.dram
                     assert dram is not None
                     cpu_availability += f"    DRAM measurements available ({dram.path})\n"
+                else:
+                    cpu_availability += "    DRAM measurements unavailable\n"
+            elif isinstance(cpu, EMICPU):
+                emi_path = cpu._emi_file.path
+                cpu_availability += (
+                    f"  CPU {i}:\n    CPU measurements available (EMI channel {cpu._pkg_channel_index} on {emi_path})\n"
+                )
+                if cpu.supports_get_dram_energy_consumption():
+                    cpu_availability += (
+                        f"    DRAM measurements available (EMI channel {cpu._dram_channel_index} on {emi_path})\n"
+                    )
                 else:
                     cpu_availability += "    DRAM measurements unavailable\n"
             else:


### PR DESCRIPTION
This PR adds CPU energy monitoring on Windows through Microsoft's Energy Meter Interface (EMI), which exposes Intel RAPL counters via a standardized IOCTL interface. It gives Windows users an alternative to the now deprecated Intel Power Gadget.

### What is included

- A new module `zeus/device/cpu/emi.py` with the `EMIFile`, `EMICPU`, and `EMICPUs` classes, device enumeration, and an `emi_is_available` check
- Wiring in `get_cpus` so EMI is selected on Windows while RAPL stays the default on Linux, plus Windows CPU package index detection
- Tests covering metadata parsing, energy unit conversion, and the CPU manager, along with a Windows only integration test

### Testing

- `ruff check` and `ruff format` both pass on the changed files
- `ty check zeus` reports no new issues for these files
- All 25 EMI unit tests pass

Closes #232
