### PR TITLE
Bump minimum ROCm version support to 6.3

### DIFF
--- a/docs/measure/index.md
+++ b/docs/measure/index.md
@@ -175,7 +175,7 @@ Four functions are exposed:
 
 ## Hardware Support
 
-For GPUs, we currently support both NVIDIA (via NVML) and AMD GPUs (via AMDSMI, with ROCm 6.2 or later).
+For GPUs, we currently support both NVIDIA (via NVML) and AMD GPUs (via AMDSMI, with ROCm 6.3 or later).
 
 CPU measurement is supported for devices that have the RAPL interface built in.
 This includes the majority of Intel CPUs and most modern AMD CPUs.
@@ -203,7 +203,7 @@ These [`GPU`][zeus.device.gpu.common.GPU] objects directly call respective `nvml
 `amdsmi.amdsmi_get_power_info` provides "average_socket_power" and "current_socket_power" fields, but the "current_socket_power" field is sometimes not supported and returns "N/A." During the [`AMDGPUs`][zeus.device.gpu.AMDGPUs] object initialization, this method is checked, and if "N/A" is returned, the [`AMDGPU.get_instant_power_usage`][zeus.device.gpu.amd.AMDGPU.get_instant_power_usage] method is disabled. Instead, [`AMDGPU.get_average_power_usage`][zeus.device.gpu.amd.AMDGPU.get_average_power_usage] needs to be used.
 
 #### ROCm and AMDSMI Versions
-Only ROCm >= 6.2 is supported. Older versions returned wrong values from the AMDSMI power and energy APIs (see [AMDSMI issue #22](https://github.com/ROCm/amdsmi/issues/22)), and versions before 6.2 lack `amdsmi_get_gpu_enumeration_info`, which Zeus uses for HIP-index resolution. Ensure your `amdsmi` and ROCm versions are up-to-date.
+Only ROCm >= 6.3 is supported. Older versions returned wrong values from the AMDSMI power and energy APIs (see [AMDSMI issue #22](https://github.com/ROCm/amdsmi/issues/22)). Zeus resolves HIP indices with `amdsmi_get_gpu_enumeration_info` on ROCm 6.4 and later, or with KFD topology `node_id` ordering on ROCm 6.3. Ensure your `amdsmi` and ROCm versions are up-to-date.
 
 #### GPU indices and `HIP_VISIBLE_DEVICES`
 

--- a/tests/device/gpu/test_amd.py
+++ b/tests/device/gpu/test_amd.py
@@ -1,10 +1,10 @@
 """Tests for AMD GPU index resolution.
 
-These tests focus on the HIP-index → amdsmi-handle translation in
+These tests focus on the HIP-index to amdsmi-handle translation in
 `AMDGPU._get_handle`. On some nodes (notably MI350X) the HIP index space
 that PyTorch and `HIP_VISIBLE_DEVICES` use does not coincide with
 `amdsmi_get_processor_handles()`'s BDF-sorted ordering, so the mapping
-must come from `amdsmi_get_gpu_enumeration_info(handle)["hip_id"]`.
+must come from amdsmi's enumeration or KFD topology information.
 """
 
 from __future__ import annotations
@@ -15,20 +15,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
-def _make_amdsmi_mock(hip_id_by_handle: dict[str, int]) -> MagicMock:
-    """Build a fake `amdsmi` module.
-
-    Args:
-        hip_id_by_handle: Maps amd-smi handle (a sentinel string standing in
-            for an opaque processor handle) to its HIP index. The order of
-            this dict is the order `amdsmi_get_processor_handles()` returns,
-            i.e., amd-smi's own GPU index space (BDF-sorted on real hardware).
-    """
+def _make_base_amdsmi_mock(handles: list[str]) -> MagicMock:
+    """Build a fake `amdsmi` module without either index-mapping API."""
     amdsmi = MagicMock()
-
-    handles = list(hip_id_by_handle.keys())
     amdsmi.amdsmi_get_processor_handles.return_value = handles
-    amdsmi.amdsmi_get_gpu_enumeration_info.side_effect = lambda h: {"hip_id": hip_id_by_handle[h]}
+    del amdsmi.amdsmi_get_gpu_enumeration_info
+    del amdsmi.amdsmi_get_gpu_kfd_info
 
     class _AmdSmiLibraryException(Exception):
         def get_error_code(self):
@@ -38,6 +30,29 @@ def _make_amdsmi_mock(hip_id_by_handle: dict[str, int]) -> MagicMock:
             return "mock error"
 
     amdsmi.AmdSmiLibraryException = _AmdSmiLibraryException
+    return amdsmi
+
+
+def _make_amdsmi_mock(hip_id_by_handle: dict[str, int]) -> MagicMock:
+    """Build a fake `amdsmi` module with the enumeration-info API.
+
+    Args:
+        hip_id_by_handle: Maps amd-smi handle (a sentinel string standing in
+            for an opaque processor handle) to its HIP index. The order of
+            this dict is the order `amdsmi_get_processor_handles()` returns,
+            i.e., amd-smi's own GPU index space (BDF-sorted on real hardware).
+    """
+    handles = list(hip_id_by_handle.keys())
+    amdsmi = _make_base_amdsmi_mock(handles)
+    amdsmi.amdsmi_get_gpu_enumeration_info = MagicMock(side_effect=lambda h: {"hip_id": hip_id_by_handle[h]})
+    return amdsmi
+
+
+def _make_kfd_amdsmi_mock(node_id_by_handle: dict[str, int | str]) -> MagicMock:
+    """Build a fake `amdsmi` module with the KFD-info API."""
+    handles = list(node_id_by_handle.keys())
+    amdsmi = _make_base_amdsmi_mock(handles)
+    amdsmi.amdsmi_get_gpu_kfd_info = MagicMock(side_effect=lambda h: {"node_id": node_id_by_handle[h]})
     return amdsmi
 
 
@@ -107,3 +122,32 @@ def test_get_handle_raises_for_missing_hip_index(fresh_amd_module):
     # `HIP_VISIBLE_DEVICES` mismatches.
     assert "HIP index 7" in str(exc_info.value)
     assert "[0, 1]" in str(exc_info.value)
+
+
+def test_get_handle_maps_kfd_node_order_to_hip_indices(fresh_amd_module):
+    amdsmi_mock = _make_kfd_amdsmi_mock({"h_a": 2, "h_b": 0, "h_c": 1})
+    amd = fresh_amd_module(amdsmi_mock)
+
+    assert amd.AMDGPU(0).handle == "h_b"
+    assert amd.AMDGPU(1).handle == "h_c"
+    assert amd.AMDGPU(2).handle == "h_a"
+
+
+def test_get_handle_raises_for_non_integer_kfd_node_id(fresh_amd_module):
+    amdsmi_mock = _make_kfd_amdsmi_mock({"h0": 0, "h1": "N/A"})
+    amd = fresh_amd_module(amdsmi_mock)
+
+    import zeus.device.gpu.common as gpu_common
+
+    with pytest.raises(gpu_common.ZeusGPUInitError, match="N/A"):
+        amd.AMDGPU(0)
+
+
+def test_get_handle_requires_amdsmi_6_3_mapping_api(fresh_amd_module):
+    amdsmi_mock = _make_base_amdsmi_mock(["h0"])
+    amd = fresh_amd_module(amdsmi_mock)
+
+    import zeus.device.gpu.common as gpu_common
+
+    with pytest.raises(gpu_common.ZeusGPUInitError, match="6\\.3"):
+        amd.AMDGPU(0)

--- a/zeus/device/gpu/__init__.py
+++ b/zeus/device/gpu/__init__.py
@@ -5,7 +5,7 @@ which returns a GPU Manager object specific to the platform.
 
 !!! Important
     In theory, any NVIDIA GPU would be supported.
-    On the other hand, for AMD GPUs, we currently only support ROCm 6.2 and later.
+    On the other hand, for AMD GPUs, we currently only support ROCm 6.3 and later.
 
 ## Getting handles to GPUs
 

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -79,7 +79,34 @@ def _hip_to_amdsmi_handle() -> dict[int, c_void_p]:
 
     The mapping is invariant for the life of the process, so it's cached.
     """
-    return {amdsmi.amdsmi_get_gpu_enumeration_info(h)["hip_id"]: h for h in amdsmi.amdsmi_get_processor_handles()}
+    handles = amdsmi.amdsmi_get_processor_handles()
+    # Version dispatch uses getattr instead of hasattr so type checkers do not
+    # mark later branches unreachable based on the locally installed amdsmi.
+    # ROCm/amdsmi 6.4+: enumeration info reports each handle's HIP index directly.
+    get_enumeration_info = getattr(amdsmi, "amdsmi_get_gpu_enumeration_info", None)
+    if get_enumeration_info is not None:
+        return {get_enumeration_info(h)["hip_id"]: h for h in handles}
+
+    # ROCm/amdsmi 6.3: no enumeration info. HIP enumerates devices in KFD
+    # topology order, so sorting handles by KFD node_id reconstructs it.
+    get_kfd_info = getattr(amdsmi, "amdsmi_get_gpu_kfd_info", None)
+    if get_kfd_info is not None:
+        logger.info("Resolving HIP indices from amdsmi KFD node IDs")
+        handles_by_node_id = []
+        for handle in handles:
+            node_id = get_kfd_info(handle)["node_id"]
+            if type(node_id) is not int:
+                raise gpu_common.ZeusGPUInitError(
+                    f"Expected an integer KFD node_id from amdsmi, but received {node_id!r}."
+                )
+            handles_by_node_id.append((node_id, handle))
+        handles_by_node_id.sort(key=lambda item: item[0])
+        return {hip_index: handle for hip_index, (_, handle) in enumerate(handles_by_node_id)}
+
+    raise gpu_common.ZeusGPUInitError(
+        "Zeus requires ROCm/amdsmi 6.3 or newer, but the installed amdsmi exposes neither "
+        "amdsmi_get_gpu_enumeration_info nor amdsmi_get_gpu_kfd_info."
+    )
 
 
 def _handle_amdsmi_errors(func):
@@ -133,12 +160,8 @@ class AMDGPU(gpu_common.GPU):
 
     @_handle_amdsmi_errors
     def _get_handle(self):
-        # `self.gpu_index` is a HIP index (what PyTorch sees), but
-        # `amdsmi_get_processor_handles()` returns handles ordered by amd-smi's
-        # own GPU index (BDF-sorted). On some nodes (e.g., MI350X) these two
-        # index spaces differ. Map HIP index -> handle via
-        # `amdsmi_get_gpu_enumeration_info`, the same source `amd-smi monitor`
-        # uses to print its HIP-ID column.
+        # Zeus accepts HIP indices, while processor handles follow amd-smi's
+        # GPU ordering. Resolve the HIP index before making amdsmi calls.
         hip_to_handle = _hip_to_amdsmi_handle()
         if self.gpu_index not in hip_to_handle:
             raise gpu_common.ZeusGPUNotFoundError(
@@ -391,45 +414,45 @@ class AMDGPUs(gpu_common.GPUs):
     """AMD GPU Manager object, containing individual AMDGPU objects, abstracting amdsmi calls and handling related exceptions.
 
     !!! Important
-        Currently only ROCm >= 6.2 is supported.
+        Currently only ROCm >= 6.3 is supported.
 
     ## Index resolution
 
     AMD systems simultaneously expose several index spaces for the same
     physical GPU, and they do not all agree:
 
-    - **HIP index** — what the HIP runtime hands out. This is what PyTorch
+    - **HIP index** - what the HIP runtime hands out. This is what PyTorch
       sees as `cuda:N`, what `torch.cuda.current_device()` returns, and what
       `HIP_VISIBLE_DEVICES` / `CUDA_VISIBLE_DEVICES` refer to.
-    - **amd-smi GPU index** — the slot number `amd-smi` and `rocm-smi` use
+    - **amd-smi GPU index** - the slot number `amd-smi` and `rocm-smi` use
       (ordered by PCI BDF). This is what appears in `amd-smi monitor`'s
       `GPU` column, what `amdsmi_get_processor_handles()` is ordered by, and
       what node-local admin scripts like `set_powercap.sh -gpu N` expect.
-    - **OAM-ID** — physical OAM tray position; not used by Zeus but shown
+    - **OAM-ID** - physical OAM tray position; not used by Zeus but shown
       by `amd-smi monitor`.
 
     On most nodes these orderings happen to coincide, but on some (e.g.,
     MI350X in SPX/NPS1), the HIP runtime enumerates GPUs in a different
-    order than PCI BDF — so HIP index 0 may be amd-smi GPU 3, and so on.
+    order than PCI BDF, so HIP index 0 may be amd-smi GPU 3, and so on.
     Mixing up the two spaces results in silently operating on the wrong
     physical GPU.
 
     Zeus sits at the application layer, so **all indices passed to Zeus are
     HIP indices** (matching PyTorch). Internally, `AMDGPU._get_handle` uses
     `amdsmi_get_gpu_enumeration_info(handle)["hip_id"]` to translate each
-    HIP index to the correct `amdsmi` processor handle before any query or
-    set — same data source `amd-smi monitor` uses to populate its `HIP-ID`
-    column.
+    HIP index to the correct `amdsmi` processor handle. On ROCm 6.3 where
+    that API is unavailable, Zeus reconstructs HIP order by sorting
+    processor handles by `amdsmi_get_gpu_kfd_info(handle)["node_id"]`.
 
     ## HIP_VISIBLE_DEVICES / CUDA_VISIBLE_DEVICES
 
     `HIP_VISIBLE_DEVICES` is respected exactly as HIP itself interprets it:
     a comma-separated list of HIP indices to expose, in order. The remaining
     GPUs are hidden; the exposed GPUs are re-numbered densely starting at 0
-    within the process (matching what PyTorch shows as `cuda:0`, `cuda:1`, …).
+    within the process (matching what PyTorch shows as `cuda:0`, `cuda:1`, ...).
 
     The index you pass to `AMDGPUs` / `GPUs` methods is this dense,
-    post-masking index — the same one PyTorch uses. Example: on a 4-GPU
+    post-masking index, the same one PyTorch uses. Example: on a 4-GPU
     node with `HIP_VISIBLE_DEVICES=0,2`, Zeus tracks two GPUs, and the
     call `gpus.get_power_management_limit(1)` hits the physical GPU whose
     HIP index (as seen by the driver before masking) was 2, i.e.,


### PR DESCRIPTION
Turns out if was already broken for 6.2 and 6.3 where `amdsmi.amdsmi_get_gpu_enumeration_info` was not available. At least 6.3 has `amdsmi.amdsmi_get_gpu_kfd_info`, so using that for 6.3 and dropping support for 6.2. This is a breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for AMD GPU HIP-index mapping with ROCm 6.3 and later.
  * Supports both ROCm 6.3 KFD topology mapping and ROCm 6.4+ device enumeration.

* **Bug Fixes**
  * Improved handling of reordered GPU mappings and non-integer device identifiers.
  * Added clear initialization failures when no supported mapping method is available.

* **Documentation**
  * Updated AMD GPU requirements from ROCm 6.2 to ROCm 6.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->