### PR TITLE
[Zeusd] `amdsmi` backend

### DIFF
--- a/.github/workflows/zeusd_fmt_lint_test.yaml
+++ b/.github/workflows/zeusd_fmt_lint_test.yaml
@@ -73,3 +73,48 @@ jobs:
       - name: Run tests without default features
         run: cargo test --no-default-features
         working-directory: zeusd
+
+  clippy_and_test_amdsmi:
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository }}
+    name: clippy + test (AMD SMI)
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: zeusd
+      - name: Install the Rust toolchain
+        run: rustup toolchain install stable --profile minimal --component clippy
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            zeusd/target/
+          key: ${{ github.event.repository.name }}-${{ runner.os }}-zeusd-cargo-v3
+      - name: Install AMD SMI
+        run: |
+          sudo mkdir -p /etc/apt/keyrings
+          wget -qO - https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
+          echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/7.2 noble main" | sudo tee /etc/apt/sources.list.d/rocm.list
+          sudo apt-get update
+          sudo apt-get install -y amd-smi-lib
+      - name: Select the installed ROCm tree
+        run: echo "ROCM_PATH=$(ls -d /opt/rocm-*)" >> "$GITHUB_ENV"
+      - name: Run clippy with AMD SMI
+        run: cargo clippy --all --features amdsmi -- -D warnings
+        working-directory: zeusd
+      - name: Run tests with AMD SMI
+        run: cargo test --features amdsmi
+        working-directory: zeusd
+      - name: Run clippy with only AMD SMI
+        run: cargo clippy --all --no-default-features --features amdsmi -- -D warnings
+        working-directory: zeusd
+      - name: Run tests with only AMD SMI
+        run: cargo test --no-default-features --features amdsmi
+        working-directory: zeusd

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -11,6 +11,7 @@ Reach for `zeusd` when you need privilege isolation for GPU configuration, CPU/D
 
 AMD GPU support covers AMD SMI from ROCm 6.3.
 An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
+Resetting locked clocks on AMD restores the driver's automatic frequency management for all clock domains at once, and per-domain resets are rejected.
 
 ## Install
 
@@ -157,9 +158,10 @@ Writes (`POST`) also take `block` (bool): `true` waits for completion and report
 | `POST` | `/gpu/set_power_limit` | `power_limit_mw` |
 | `POST` | `/gpu/set_persistence_mode` | `enabled` (see [Windows quirk](#windows-quirk)) |
 | `POST` | `/gpu/set_gpu_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
-| `POST` | `/gpu/reset_gpu_locked_clocks` | -- |
+| `POST` | `/gpu/reset_gpu_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
 | `POST` | `/gpu/set_mem_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
-| `POST` | `/gpu/reset_mem_locked_clocks` | -- |
+| `POST` | `/gpu/reset_mem_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
+| `POST` | `/gpu/reset_locked_clocks` | resets all clock domains |
 | `GET`  | `/gpu/get_cumulative_energy` | -- |
 | `GET`  | `/gpu/get_power` | one-shot snapshot |
 | `GET`  | `/gpu/stream_power` | SSE stream |

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -6,13 +6,23 @@ Reach for `zeusd` when you need privilege isolation for GPU configuration, CPU/D
 
 ## Platform support
 
-- **Linux:** UDS default. All API groups work (NVML + RAPL).
+- **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only -- `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp` (no `httpx` transport for named pipes yet).
+
+AMD GPU support covers AMD SMI from ROCm 6.3 through 7.2.
+An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install
 
 ```sh
 cargo install zeusd
+```
+
+Build AMD GPU support with `ROCM_PATH` selecting the ROCm installation.
+Specifying `--no-default-features` drops the default NVML support entirely.
+
+```sh
+ROCM_PATH=/opt/rocm-7.2.0 cargo install zeusd --no-default-features --features amdsmi
 ```
 
 Linux deployments: see [`zeusd/packaging/systemd/`](https://github.com/ml-energy/zeus/tree/master/zeusd/packaging/systemd){.external} for a hardened systemd unit.

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -9,7 +9,7 @@ Reach for `zeusd` when you need privilege isolation for GPU configuration, CPU/D
 - **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only -- `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp` (no `httpx` transport for named pipes yet).
 
-AMD GPU support covers AMD SMI from ROCm 6.3+.
+AMD GPU support covers AMD SMI from ROCm 6.3.
 An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -9,7 +9,7 @@ Reach for `zeusd` when you need privilege isolation for GPU configuration, CPU/D
 - **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only -- `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp` (no `httpx` transport for named pipes yet).
 
-AMD GPU support covers AMD SMI from ROCm 6.3 through 7.2.
+AMD GPU support covers AMD SMI from ROCm 6.3+.
 An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install

--- a/zeusd/Cargo.toml
+++ b/zeusd/Cargo.toml
@@ -39,6 +39,7 @@ humantime = "2"
 
 [features]
 default = ["nvml"]
+amdsmi = []
 nvml = ["dep:nvml-wrapper"]
 
 [target.'cfg(unix)'.dependencies]

--- a/zeusd/README.md
+++ b/zeusd/README.md
@@ -12,13 +12,23 @@ Energy optimizers in Zeus need to change GPU configuration (power limit, clocks,
 
 ## Platform support
 
-- **Linux:** UDS default. All API groups work (NVML + RAPL).
+- **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only; `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp`.
+
+AMD GPU support covers AMD SMI from ROCm 6.3 through 7.2.
+An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install
 
 ```sh
 cargo install zeusd
+```
+
+Build AMD GPU support with `ROCM_PATH` selecting the ROCm installation.
+Cargo features are additive, so this includes NVML support as well; on an AMD-only node, `--no-default-features` drops NVML entirely:
+
+```sh
+ROCM_PATH=/opt/rocm-7.2.0 cargo install zeusd --no-default-features --features amdsmi
 ```
 
 For a hardened systemd deployment, see [`packaging/systemd/`](packaging/systemd/).

--- a/zeusd/README.md
+++ b/zeusd/README.md
@@ -15,7 +15,7 @@ Energy optimizers in Zeus need to change GPU configuration (power limit, clocks,
 - **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only; `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp`.
 
-AMD GPU support covers AMD SMI from ROCm 6.3 through 7.2.
+AMD GPU support covers AMD SMI from ROCm 6.3+.
 An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install

--- a/zeusd/README.md
+++ b/zeusd/README.md
@@ -15,7 +15,7 @@ Energy optimizers in Zeus need to change GPU configuration (power limit, clocks,
 - **Linux:** UDS default. All API groups work with NVIDIA GPUs through NVML or AMD GPUs through AMD SMI, plus RAPL for CPUs.
 - **Windows:** named pipe default. NVML only; `cpu-read` is rejected at startup since RAPL is Linux-only. Python clients must use `--mode tcp`.
 
-AMD GPU support covers AMD SMI from ROCm 6.3+.
+AMD GPU support covers AMD SMI from ROCm 6.3.
 An AMD-enabled binary is tied to the ROCm ABI major it was built against, so rebuild after major ROCm upgrades; a mismatch appears as a loader error at startup.
 
 ## Install

--- a/zeusd/build.rs
+++ b/zeusd/build.rs
@@ -96,7 +96,18 @@ fn locate_library_dir() -> Option<PathBuf> {
                     .and_then(|name| name.to_str())
                     .is_some_and(|name| name.starts_with("rocm-"))
         })
-        .max()
+        .max_by_key(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .and_then(|name| name.strip_prefix("rocm-"))
+                .and_then(|version| {
+                    let mut components = version.split('.');
+                    let major: u32 = components.next()?.parse().ok()?;
+                    let minor: u32 = components.next().unwrap_or("0").parse().ok()?;
+                    Some((major, minor))
+                })
+                .unwrap_or((0, 0))
+        })
         .map(|path| path.join("lib"))
 }
 

--- a/zeusd/build.rs
+++ b/zeusd/build.rs
@@ -1,0 +1,135 @@
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const LIBRARY_NAME: &str = "libamd_smi.so";
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct LibraryVersion {
+    major: u32,
+    minor: u32,
+    patch: Option<u32>,
+}
+
+impl LibraryVersion {
+    fn parse(path: &Path) -> Option<Self> {
+        let file_name = path.file_name()?.to_str()?;
+        let version = file_name.strip_prefix("libamd_smi.so.")?;
+        let mut components = version.split('.');
+        let major = components.next()?.parse().ok()?;
+        let minor = components.next()?.parse().ok()?;
+        let patch = components.next().map(str::parse).transpose().ok()?;
+        if components.next().is_some() {
+            return None;
+        }
+        Some(Self {
+            major,
+            minor,
+            patch,
+        })
+    }
+
+    fn display(&self) -> String {
+        match self.patch {
+            Some(patch) => format!("{}.{}.{}", self.major, self.minor, patch),
+            None => format!("{}.{}", self.major, self.minor),
+        }
+    }
+}
+
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(amdsmi_abi, values(\"24\", \"25\", \"26\"))");
+    println!("cargo:rerun-if-env-changed=AMDSMI_LIB_DIR");
+    println!("cargo:rerun-if-env-changed=ROCM_PATH");
+
+    if env::var_os("CARGO_FEATURE_AMDSMI").is_none() {
+        return;
+    }
+
+    let library_dir = locate_library_dir().unwrap_or_else(|| {
+        panic!(
+            "could not locate {LIBRARY_NAME}; set ROCM_PATH to the ROCm installation root or \
+             AMDSMI_LIB_DIR to the directory containing {LIBRARY_NAME}"
+        )
+    });
+    let version = find_library_version(&library_dir).unwrap_or_else(|| {
+        panic!(
+            "could not find a fully versioned {LIBRARY_NAME} in {}; set ROCM_PATH to the ROCm \
+             installation root or AMDSMI_LIB_DIR to the directory containing {LIBRARY_NAME}",
+            library_dir.display()
+        )
+    });
+
+    validate_version(&version);
+
+    println!("cargo:rustc-link-search=native={}", library_dir.display());
+    println!("cargo:rustc-link-lib=dylib=amd_smi");
+    println!("cargo:rustc-cfg=amdsmi_abi=\"{}\"", version.major);
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", library_dir.display());
+    println!(
+        "cargo:rustc-env=ZEUSD_AMDSMI_BUILD_VERSION={}",
+        version.display()
+    );
+}
+
+fn locate_library_dir() -> Option<PathBuf> {
+    if let Some(path) = env::var_os("AMDSMI_LIB_DIR") {
+        return Some(PathBuf::from(path));
+    }
+    if let Some(path) = env::var_os("ROCM_PATH") {
+        return Some(PathBuf::from(path).join("lib"));
+    }
+
+    let default_rocm = PathBuf::from("/opt/rocm");
+    if default_rocm.exists() {
+        return Some(default_rocm.join("lib"));
+    }
+
+    fs::read_dir("/opt")
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_dir()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("rocm-"))
+        })
+        .max()
+        .map(|path| path.join("lib"))
+}
+
+fn find_library_version(library_dir: &Path) -> Option<LibraryVersion> {
+    let unversioned = library_dir.join(LIBRARY_NAME);
+    if fs::symlink_metadata(&unversioned).is_ok() {
+        if let Ok(resolved) = fs::canonicalize(&unversioned) {
+            if let Some(version) = LibraryVersion::parse(&resolved) {
+                return Some(version);
+            }
+        }
+    }
+
+    fs::read_dir(library_dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .filter(|entry| {
+            entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| name.starts_with(LIBRARY_NAME))
+        })
+        .filter_map(|entry| fs::canonicalize(entry.path()).ok())
+        .filter_map(|path| LibraryVersion::parse(&path))
+        .max()
+}
+
+fn validate_version(version: &LibraryVersion) {
+    match (version.major, version.minor) {
+        (24, 6) => {
+            panic!("found libamd_smi.so 24.6 (ROCm 6.2); zeusd supports ROCm 6.3 and newer")
+        }
+        (24, 7..) | (25, _) | (26, _) => {}
+        _ => panic!("unsupported amd-smi ABI; this zeusd release supports ROCm 6.3 through 7.2"),
+    }
+}

--- a/zeusd/src/config.rs
+++ b/zeusd/src/config.rs
@@ -61,6 +61,27 @@ impl std::fmt::Display for ApiGroup {
     }
 }
 
+/// GPU management backend selection.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, ValueEnum)]
+pub enum GpuBackend {
+    /// Probe compiled backends and select the one that reports GPUs.
+    Auto,
+    /// Use NVIDIA Management Library.
+    Nvml,
+    /// Use AMD SMI.
+    Amdsmi,
+}
+
+impl std::fmt::Display for GpuBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GpuBackend::Auto => write!(f, "auto"),
+            GpuBackend::Nvml => write!(f, "nvml"),
+            GpuBackend::Amdsmi => write!(f, "amdsmi"),
+        }
+    }
+}
+
 /// The Zeus daemon manages and monitors compute devices on the node.
 #[derive(Parser, Debug)]
 #[command(version)]
@@ -140,6 +161,11 @@ pub struct ServeConfig {
     #[clap(long, default_value = "20")]
     pub gpu_power_poll_hz: u32,
 
+    /// GPU backend to use. `auto` probes compiled backends and picks the one
+    /// that reports GPUs; an explicit choice fails fast if unavailable.
+    #[clap(long, default_value = "auto")]
+    pub gpu_backend: GpuBackend,
+
     /// CPU RAPL power polling frequency in Hz for the streaming endpoint.
     #[clap(long, default_value = "10")]
     pub cpu_power_poll_hz: u32,
@@ -148,10 +174,10 @@ pub struct ServeConfig {
     /// exit at startup if not running as root. Defaults include the API groups
     /// supported by the platform and compiled device backends.
     #[clap(long, value_delimiter = ',')]
-    #[cfg_attr(all(target_os = "linux", feature = "nvml"), clap(
+    #[cfg_attr(all(target_os = "linux", any(feature = "nvml", feature = "amdsmi")), clap(
         default_values_t = [ApiGroup::GpuControl, ApiGroup::GpuRead, ApiGroup::CpuRead],
     ))]
-    #[cfg_attr(all(target_os = "linux", not(feature = "nvml")), clap(
+    #[cfg_attr(all(target_os = "linux", not(any(feature = "nvml", feature = "amdsmi"))), clap(
         default_values_t = [ApiGroup::CpuRead],
     ))]
     #[cfg_attr(all(not(target_os = "linux"), feature = "nvml"), clap(

--- a/zeusd/src/devices/gpu/amdsmi/ffi.rs
+++ b/zeusd/src/devices/gpu/amdsmi/ffi.rs
@@ -1,0 +1,280 @@
+//! Raw bindings to `libamd_smi.so`.
+
+use std::ffi::{c_char, c_void};
+use std::fmt;
+
+pub type AmdsmiProcessorHandle = *mut c_void;
+pub type AmdsmiSocketHandle = *mut c_void;
+pub type AmdsmiStatus = u32;
+
+pub const AMDSMI_STATUS_SUCCESS: AmdsmiStatus = 0;
+pub const AMDSMI_STATUS_INVAL: AmdsmiStatus = 1;
+pub const AMDSMI_STATUS_NOT_SUPPORTED: AmdsmiStatus = 2;
+pub const AMDSMI_STATUS_NO_PERM: AmdsmiStatus = 10;
+pub const AMDSMI_STATUS_NOT_FOUND: AmdsmiStatus = 31;
+pub const AMDSMI_STATUS_NOT_INIT: AmdsmiStatus = 32;
+
+pub const AMDSMI_INIT_AMD_GPUS: u64 = 2;
+
+pub const AMDSMI_CLK_TYPE_GFX: u32 = 0;
+pub const AMDSMI_CLK_TYPE_MEM: u32 = 4;
+
+pub const AMDSMI_CLK_LIMIT_MIN: u32 = 0;
+pub const AMDSMI_CLK_LIMIT_MAX: u32 = 1;
+
+/// GPU power-cap information in uW.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiPowerCapInfo {
+    pub power_cap: u64,
+    pub default_power_cap: u64,
+    pub dpm_cap: u64,
+    pub min_power_cap: u64,
+    pub max_power_cap: u64,
+    pub reserved: [u64; 3],
+}
+
+/// GPU clock information in MHz.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiClkInfo {
+    pub clk: u32,
+    pub min_clk: u32,
+    pub max_clk: u32,
+    pub clk_locked: u8,
+    pub clk_deep_sleep: u8,
+    pub reserved: [u32; 4],
+}
+
+/// GPU power information with power fields in W and voltage fields in mV.
+#[cfg(amdsmi_abi = "24")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiPowerInfo {
+    pub current_socket_power: u32,
+    pub average_socket_power: u32,
+    pub gfx_voltage: u32,
+    pub soc_voltage: u32,
+    pub mem_voltage: u32,
+    pub power_limit: u32,
+    pub reserved: [u32; 11],
+}
+
+/// GPU power information with power fields in W and voltage fields in mV.
+#[cfg(amdsmi_abi = "25")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiPowerInfo {
+    pub socket_power: u64,
+    pub current_socket_power: u32,
+    pub average_socket_power: u32,
+    pub gfx_voltage: u32,
+    pub soc_voltage: u32,
+    pub mem_voltage: u32,
+    pub power_limit: u32,
+    pub reserved: [u32; 2],
+}
+
+/// GPU power information with power fields in W and voltage fields in mV.
+#[cfg(amdsmi_abi = "26")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiPowerInfo {
+    pub socket_power: u64,
+    pub current_socket_power: u32,
+    pub average_socket_power: u32,
+    pub gfx_voltage: u64,
+    pub soc_voltage: u64,
+    pub mem_voltage: u64,
+    pub power_limit: u32,
+    pub reserved: [u64; 18],
+}
+
+#[cfg(any(amdsmi_abi = "24", amdsmi_abi = "25"))]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiVersion {
+    pub year: u32,
+    pub major: u32,
+    pub minor: u32,
+    pub release: u32,
+    pub build: *const c_char,
+}
+
+#[cfg(amdsmi_abi = "26")]
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiVersion {
+    pub major: u32,
+    pub minor: u32,
+    pub release: u32,
+    pub build: *const c_char,
+}
+
+/// ASIC information returned by AMD SMI.
+///
+/// The real C struct is about 448 bytes on ABI 24 and about 896 bytes on ABI 26, and only `market_name` at offset 0 is read; 1024 bytes safely over-allocates the out-buffer for every supported ABI.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct AmdsmiAsicInfo {
+    pub market_name: [c_char; 256],
+    pub _rest: [u8; 768],
+}
+
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy)]
+pub struct Bdf(pub u64);
+
+impl Bdf {
+    pub fn function(self) -> u8 {
+        (self.0 & 0x7) as u8
+    }
+
+    pub fn device(self) -> u8 {
+        ((self.0 >> 3) & 0x1f) as u8
+    }
+
+    pub fn bus(self) -> u8 {
+        ((self.0 >> 8) & 0xff) as u8
+    }
+
+    pub fn domain(self) -> u64 {
+        self.0 >> 16
+    }
+}
+
+impl fmt::Display for Bdf {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{:04x}:{:02x}:{:02x}.{:x}",
+            self.domain(),
+            self.bus(),
+            self.device(),
+            self.function()
+        )
+    }
+}
+
+extern "C" {
+    pub fn amdsmi_init(init_flags: u64) -> AmdsmiStatus;
+    pub fn amdsmi_shut_down() -> AmdsmiStatus;
+    pub fn amdsmi_get_socket_handles(
+        socket_count: *mut u32,
+        socket_handles: *mut AmdsmiSocketHandle,
+    ) -> AmdsmiStatus;
+    pub fn amdsmi_get_processor_handles(
+        socket_handle: AmdsmiSocketHandle,
+        processor_count: *mut u32,
+        processor_handles: *mut AmdsmiProcessorHandle,
+    ) -> AmdsmiStatus;
+    pub fn amdsmi_get_gpu_asic_info(
+        processor_handle: AmdsmiProcessorHandle,
+        info: *mut AmdsmiAsicInfo,
+    ) -> AmdsmiStatus;
+    pub fn amdsmi_get_gpu_device_bdf(
+        processor_handle: AmdsmiProcessorHandle,
+        bdf: *mut Bdf,
+    ) -> AmdsmiStatus;
+    /// Writes power-cap information in uW.
+    pub fn amdsmi_get_power_cap_info(
+        processor_handle: AmdsmiProcessorHandle,
+        sensor_ind: u32,
+        info: *mut AmdsmiPowerCapInfo,
+    ) -> AmdsmiStatus;
+    /// Sets the power cap in uW.
+    pub fn amdsmi_set_power_cap(
+        processor_handle: AmdsmiProcessorHandle,
+        sensor_ind: u32,
+        cap: u64,
+    ) -> AmdsmiStatus;
+    /// Writes power information whose power fields are in W.
+    pub fn amdsmi_get_power_info(
+        processor_handle: AmdsmiProcessorHandle,
+        info: *mut AmdsmiPowerInfo,
+    ) -> AmdsmiStatus;
+    /// Writes an energy count, its resolution in uJ per count, and a timestamp in ns.
+    pub fn amdsmi_get_energy_count(
+        processor_handle: AmdsmiProcessorHandle,
+        energy_accumulator: *mut u64,
+        counter_resolution: *mut f32,
+        timestamp: *mut u64,
+    ) -> AmdsmiStatus;
+    /// Writes GPU clock information in MHz.
+    pub fn amdsmi_get_clock_info(
+        processor_handle: AmdsmiProcessorHandle,
+        clk_type: u32,
+        info: *mut AmdsmiClkInfo,
+    ) -> AmdsmiStatus;
+    pub fn amdsmi_get_lib_version(version: *mut AmdsmiVersion) -> AmdsmiStatus;
+    pub fn amdsmi_status_code_to_string(
+        status: AmdsmiStatus,
+        status_string: *mut *const c_char,
+    ) -> AmdsmiStatus;
+
+    /// Sets one GPU clock limit in MHz. Exported by libamd_smi since 24.7 (ROCm 6.3),
+    /// which is zeusd's build floor, and the only clock setter remaining in ABI 27.
+    pub fn amdsmi_set_gpu_clk_limit(
+        processor_handle: AmdsmiProcessorHandle,
+        clk_type: u32,
+        limit_type: u32,
+        clk_value: u64,
+    ) -> AmdsmiStatus;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::{offset_of, size_of};
+
+    // Expected values come from amdsmi-abi/<version>/amdsmi_wrapper.py.
+    #[test]
+    fn common_struct_layouts() {
+        assert_eq!(size_of::<AmdsmiPowerCapInfo>(), 64);
+        assert_eq!(size_of::<AmdsmiClkInfo>(), 32);
+        assert_eq!(size_of::<AmdsmiAsicInfo>(), 1024);
+        assert_eq!(offset_of!(AmdsmiAsicInfo, market_name), 0);
+        assert_eq!(size_of::<Bdf>(), 8);
+    }
+
+    #[cfg(amdsmi_abi = "24")]
+    #[test]
+    fn abi_24_struct_layouts() {
+        assert_eq!(size_of::<AmdsmiPowerInfo>(), 68);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, current_socket_power), 0);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, average_socket_power), 4);
+        assert_eq!(size_of::<AmdsmiVersion>(), 24);
+        assert_eq!(offset_of!(AmdsmiVersion, major), 4);
+    }
+
+    #[cfg(amdsmi_abi = "25")]
+    #[test]
+    fn abi_25_struct_layouts() {
+        assert_eq!(size_of::<AmdsmiPowerInfo>(), 40);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, current_socket_power), 8);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, average_socket_power), 12);
+        assert_eq!(size_of::<AmdsmiVersion>(), 24);
+        assert_eq!(offset_of!(AmdsmiVersion, major), 4);
+    }
+
+    #[cfg(amdsmi_abi = "26")]
+    #[test]
+    fn abi_26_struct_layouts() {
+        assert_eq!(size_of::<AmdsmiPowerInfo>(), 192);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, current_socket_power), 8);
+        assert_eq!(offset_of!(AmdsmiPowerInfo, average_socket_power), 12);
+        assert_eq!(size_of::<AmdsmiVersion>(), 24);
+        assert_eq!(offset_of!(AmdsmiVersion, major), 0);
+    }
+
+    #[test]
+    fn bdf_fields_and_display() {
+        let bdf = Bdf((1_u64 << 16) | (0xc5_u64 << 8));
+
+        assert_eq!(bdf.domain(), 0x0001);
+        assert_eq!(bdf.bus(), 0xc5);
+        assert_eq!(bdf.device(), 0x00);
+        assert_eq!(bdf.function(), 0);
+        assert_eq!(bdf.to_string(), "0001:c5:00.0");
+    }
+}

--- a/zeusd/src/devices/gpu/amdsmi/ffi.rs
+++ b/zeusd/src/devices/gpu/amdsmi/ffi.rs
@@ -22,6 +22,11 @@ pub const AMDSMI_CLK_TYPE_MEM: u32 = 4;
 pub const AMDSMI_CLK_LIMIT_MIN: u32 = 0;
 pub const AMDSMI_CLK_LIMIT_MAX: u32 = 1;
 
+/// Unavailable power value originating from u16 GPU metrics fields, which the library pre-fills with 0xFFFF.
+pub const AMDSMI_POWER_NA: u32 = 0xFFFF;
+
+pub const AMDSMI_DEV_PERF_LEVEL_AUTO: u32 = 0;
+
 /// GPU power-cap information in uW.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
@@ -219,6 +224,12 @@ extern "C" {
         clk_type: u32,
         limit_type: u32,
         clk_value: u64,
+    ) -> AmdsmiStatus;
+
+    /// Sets the GPU performance level. Leaving manual mode restores default clock limits, while clock-limit writes force manual mode.
+    pub fn amdsmi_set_gpu_perf_level(
+        processor_handle: AmdsmiProcessorHandle,
+        perf_level: u32,
     ) -> AmdsmiStatus;
 }
 

--- a/zeusd/src/devices/gpu/amdsmi/mod.rs
+++ b/zeusd/src/devices/gpu/amdsmi/mod.rs
@@ -26,6 +26,9 @@ enum PowerReading {
 pub struct AmdsmiGpu {
     handle: ffi::AmdsmiProcessorHandle,
     power_reading: PowerReading,
+    // Single-task ownership serializes cache updates; failed writes requery bounds to cover external changes.
+    gfx_clock_bounds: Option<(u32, u32)>,
+    mem_clock_bounds: Option<(u32, u32)>,
 }
 
 // SAFETY: Processor handles are process-wide identifiers into the thread-safe
@@ -133,6 +136,20 @@ fn clock_info(
     Ok(unsafe { info.assume_init() })
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WriteOrder {
+    MinFirst,
+    MaxFirst,
+}
+
+fn clk_write_order(cached: Option<(u32, u32)>, new_min: u32, _new_max: u32) -> WriteOrder {
+    if cached.is_some_and(|(_, cached_max)| new_min > cached_max) {
+        WriteOrder::MaxFirst
+    } else {
+        WriteOrder::MinFirst
+    }
+}
+
 impl AmdsmiGpu {
     /// Initialize an AMD SMI handle for a GPU index.
     pub fn init(index: u32) -> Result<Self, ZeusdError> {
@@ -142,9 +159,9 @@ impl AmdsmiGpu {
             .copied()
             .ok_or(ZeusdError::GpuNotFoundError(index as usize))?;
         let power = power_info(handle)?;
-        let power_reading = if power.current_socket_power != u32::MAX {
+        let power_reading = if power.current_socket_power != ffi::AMDSMI_POWER_NA {
             PowerReading::Current
-        } else if power.average_socket_power != u32::MAX {
+        } else if power.average_socket_power != ffi::AMDSMI_POWER_NA {
             PowerReading::Average
         } else {
             PowerReading::Unsupported
@@ -155,9 +172,35 @@ impl AmdsmiGpu {
             power_reading
         );
 
+        // `clock_info` min/max semantics vary by AMD SMI version; 6.4 excludes the current level from the range, and mis-seeds self-correct through the set path's requery fallback.
+        let gfx_clock_bounds = match clock_info(handle, ffi::AMDSMI_CLK_TYPE_GFX) {
+            Ok(info) => Some((info.min_clk, info.max_clk)),
+            Err(error) => {
+                tracing::debug!(
+                    "Could not cache GFX clock bounds for AMD SMI GPU {}: {}",
+                    index,
+                    error
+                );
+                None
+            }
+        };
+        let mem_clock_bounds = match clock_info(handle, ffi::AMDSMI_CLK_TYPE_MEM) {
+            Ok(info) => Some((info.min_clk, info.max_clk)),
+            Err(error) => {
+                tracing::debug!(
+                    "Could not cache MEM clock bounds for AMD SMI GPU {}: {}",
+                    index,
+                    error
+                );
+                None
+            }
+        };
+
         let gpu = Self {
             handle,
             power_reading,
+            gfx_clock_bounds,
+            mem_clock_bounds,
         };
         let name = gpu.name()?;
         let bdf = gpu.bdf()?;
@@ -198,35 +241,111 @@ impl AmdsmiGpu {
         Ok(unsafe { bdf.assume_init() })
     }
 
-    fn set_locked_clocks(
+    fn clock_bounds(&self, clock_type: u32) -> Option<(u32, u32)> {
+        match clock_type {
+            ffi::AMDSMI_CLK_TYPE_GFX => self.gfx_clock_bounds,
+            ffi::AMDSMI_CLK_TYPE_MEM => self.mem_clock_bounds,
+            _ => unreachable!("unsupported AMD SMI clock type: {clock_type}"),
+        }
+    }
+
+    fn set_clock_bounds(&mut self, clock_type: u32, bounds: Option<(u32, u32)>) {
+        match clock_type {
+            ffi::AMDSMI_CLK_TYPE_GFX => self.gfx_clock_bounds = bounds,
+            ffi::AMDSMI_CLK_TYPE_MEM => self.mem_clock_bounds = bounds,
+            _ => unreachable!("unsupported AMD SMI clock type: {clock_type}"),
+        }
+    }
+
+    fn write_locked_clocks(
         &self,
         clock_type: u32,
         min_clock_mhz: u32,
         max_clock_mhz: u32,
+        order: WriteOrder,
     ) -> Result<(), ZeusdError> {
-        // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
-        check_status(unsafe {
-            ffi::amdsmi_set_gpu_clk_limit(
-                self.handle,
-                clock_type,
-                ffi::AMDSMI_CLK_LIMIT_MIN,
-                u64::from(min_clock_mhz),
-            )
-        })?;
-        // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
-        check_status(unsafe {
-            ffi::amdsmi_set_gpu_clk_limit(
-                self.handle,
-                clock_type,
-                ffi::AMDSMI_CLK_LIMIT_MAX,
-                u64::from(max_clock_mhz),
-            )
-        })
+        let limits = match order {
+            WriteOrder::MinFirst => [
+                (ffi::AMDSMI_CLK_LIMIT_MIN, min_clock_mhz),
+                (ffi::AMDSMI_CLK_LIMIT_MAX, max_clock_mhz),
+            ],
+            WriteOrder::MaxFirst => [
+                (ffi::AMDSMI_CLK_LIMIT_MAX, max_clock_mhz),
+                (ffi::AMDSMI_CLK_LIMIT_MIN, min_clock_mhz),
+            ],
+        };
+        for (limit_type, clock_mhz) in limits {
+            // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
+            check_status(unsafe {
+                ffi::amdsmi_set_gpu_clk_limit(
+                    self.handle,
+                    clock_type,
+                    limit_type,
+                    u64::from(clock_mhz),
+                )
+            })?;
+        }
+        Ok(())
     }
 
-    fn reset_locked_clocks(&self, clock_type: u32) -> Result<(), ZeusdError> {
+    fn set_locked_clocks(
+        &mut self,
+        clock_type: u32,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        let cached = match self.clock_bounds(clock_type) {
+            Some(bounds) => Some(bounds),
+            None => {
+                let info = clock_info(self.handle, clock_type)?;
+                let bounds = (info.min_clk, info.max_clk);
+                self.set_clock_bounds(clock_type, Some(bounds));
+                Some(bounds)
+            }
+        };
+        let order = clk_write_order(cached, min_clock_mhz, max_clock_mhz);
+
+        match self.write_locked_clocks(clock_type, min_clock_mhz, max_clock_mhz, order) {
+            Ok(()) => {
+                self.set_clock_bounds(clock_type, Some((min_clock_mhz, max_clock_mhz)));
+                return Ok(());
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to set AMD SMI GPU clock type {} range: {}; the GPU's clock range was likely changed outside zeusd, requerying and retrying",
+                    clock_type,
+                    error
+                );
+                self.set_clock_bounds(clock_type, None);
+            }
+        }
+
         let info = clock_info(self.handle, clock_type)?;
-        self.set_locked_clocks(clock_type, info.min_clk, info.max_clk)
+        let queried_bounds = (info.min_clk, info.max_clk);
+        let order = clk_write_order(Some(queried_bounds), min_clock_mhz, max_clock_mhz);
+        match self.write_locked_clocks(clock_type, min_clock_mhz, max_clock_mhz, order) {
+            Ok(()) => {
+                self.set_clock_bounds(clock_type, Some((min_clock_mhz, max_clock_mhz)));
+                Ok(())
+            }
+            Err(error) => {
+                self.set_clock_bounds(clock_type, None);
+                if let Some(bounds) = cached {
+                    let revert_order = clk_write_order(Some(queried_bounds), bounds.0, bounds.1);
+                    match self.write_locked_clocks(clock_type, bounds.0, bounds.1, revert_order) {
+                        Ok(()) => self.set_clock_bounds(clock_type, Some(bounds)),
+                        Err(revert_error) => {
+                            tracing::warn!(
+                                "Failed to restore AMD SMI GPU clock type {} range after set failure: {}",
+                                clock_type,
+                                revert_error
+                            );
+                        }
+                    }
+                }
+                Err(error)
+            }
+        }
     }
 }
 
@@ -275,7 +394,10 @@ impl GpuManager for AmdsmiGpu {
     }
 
     fn reset_gpu_locked_clocks(&mut self) -> Result<(), ZeusdError> {
-        self.reset_locked_clocks(ffi::AMDSMI_CLK_TYPE_GFX)
+        Err(ZeusdError::InvalidRequest(
+            "AMD GPUs cannot reset a single clock domain; use reset_locked_clocks to reset all domains"
+                .into(),
+        ))
     }
 
     fn set_mem_locked_clocks(
@@ -287,7 +409,23 @@ impl GpuManager for AmdsmiGpu {
     }
 
     fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError> {
-        self.reset_locked_clocks(ffi::AMDSMI_CLK_TYPE_MEM)
+        Err(ZeusdError::InvalidRequest(
+            "AMD GPUs cannot reset a single clock domain; use reset_locked_clocks to reset all domains"
+                .into(),
+        ))
+    }
+
+    /// AMD offers no per-domain reset, so this restores the driver's automatic
+    /// frequency management for all clock domains and lets the kernel restore
+    /// default limits.
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
+        check_status(unsafe {
+            ffi::amdsmi_set_gpu_perf_level(self.handle, ffi::AMDSMI_DEV_PERF_LEVEL_AUTO)
+        })?;
+        self.gfx_clock_bounds = None;
+        self.mem_clock_bounds = None;
+        Ok(())
     }
 
     fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {
@@ -299,7 +437,7 @@ impl GpuManager for AmdsmiGpu {
                 return Err(amdsmi_error(ffi::AMDSMI_STATUS_NOT_SUPPORTED));
             }
         };
-        if power_w == u32::MAX {
+        if power_w == ffi::AMDSMI_POWER_NA {
             return Err(amdsmi_error(ffi::AMDSMI_STATUS_NOT_SUPPORTED));
         }
         Ok(power_w * 1000)
@@ -319,5 +457,47 @@ impl GpuManager for AmdsmiGpu {
             )
         })?;
         Ok((energy_accumulator as f64 * counter_resolution as f64 / 1000.0) as u64)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clk_write_order_raises_both_max_first() {
+        assert_eq!(
+            clk_write_order(Some((1_000, 1_500)), 1_600, 1_800),
+            WriteOrder::MaxFirst
+        );
+    }
+
+    #[test]
+    fn clk_write_order_lowers_both_min_first() {
+        assert_eq!(
+            clk_write_order(Some((1_000, 1_500)), 500, 900),
+            WriteOrder::MinFirst
+        );
+    }
+
+    #[test]
+    fn clk_write_order_overlapping_range_min_first() {
+        assert_eq!(
+            clk_write_order(Some((1_000, 1_500)), 1_200, 1_800),
+            WriteOrder::MinFirst
+        );
+    }
+
+    #[test]
+    fn clk_write_order_without_cache_min_first() {
+        assert_eq!(clk_write_order(None, 1_600, 1_800), WriteOrder::MinFirst);
+    }
+
+    #[test]
+    fn clk_write_order_equal_cached_max_min_first() {
+        assert_eq!(
+            clk_write_order(Some((1_000, 1_500)), 1_500, 1_800),
+            WriteOrder::MinFirst
+        );
     }
 }

--- a/zeusd/src/devices/gpu/amdsmi/mod.rs
+++ b/zeusd/src/devices/gpu/amdsmi/mod.rs
@@ -1,0 +1,323 @@
+//! Implements `AmdsmiGpu`, a GPU manager for AMD GPUs using AMD SMI.
+//!
+//! AMD SMI is available on Linux as part of ROCm. The library is initialized
+//! once and remains initialized for the lifetime of the daemon.
+
+use std::mem::MaybeUninit;
+use std::ptr;
+
+use once_cell::sync::OnceCell;
+
+use crate::devices::gpu::GpuManager;
+use crate::error::ZeusdError;
+
+pub mod ffi;
+
+static AMDSMI_INIT_STATUS: OnceCell<ffi::AmdsmiStatus> = OnceCell::new();
+
+#[derive(Clone, Copy, Debug)]
+enum PowerReading {
+    Current,
+    Average,
+    Unsupported,
+}
+
+/// A GPU managed through AMD SMI.
+pub struct AmdsmiGpu {
+    handle: ffi::AmdsmiProcessorHandle,
+    power_reading: PowerReading,
+}
+
+// SAFETY: Processor handles are process-wide identifiers into the thread-safe
+// AMD SMI library, not thread-local resources.
+unsafe impl Send for AmdsmiGpu {}
+
+fn amdsmi_error(status: ffi::AmdsmiStatus) -> ZeusdError {
+    let mut message_ptr = ptr::null();
+    // SAFETY: AMD SMI writes a borrowed pointer to a static status string.
+    let message_status = unsafe { ffi::amdsmi_status_code_to_string(status, &mut message_ptr) };
+    let msg = if message_status == ffi::AMDSMI_STATUS_SUCCESS && !message_ptr.is_null() {
+        // SAFETY: A successful call returns a valid NUL-terminated string.
+        unsafe { std::ffi::CStr::from_ptr(message_ptr) }
+            .to_string_lossy()
+            .into_owned()
+    } else {
+        status.to_string()
+    };
+    ZeusdError::AmdSmiError { status, msg }
+}
+
+fn check_status(status: ffi::AmdsmiStatus) -> Result<(), ZeusdError> {
+    if status == ffi::AMDSMI_STATUS_SUCCESS {
+        Ok(())
+    } else {
+        Err(amdsmi_error(status))
+    }
+}
+
+fn init_amdsmi() -> Result<(), ZeusdError> {
+    let status = AMDSMI_INIT_STATUS.get_or_init(|| {
+        // SAFETY: This process-global call is executed exactly once by `OnceCell`.
+        unsafe { ffi::amdsmi_init(ffi::AMDSMI_INIT_AMD_GPUS) }
+    });
+    check_status(*status)
+}
+
+fn socket_handles() -> Result<Vec<ffi::AmdsmiSocketHandle>, ZeusdError> {
+    let mut count = 0;
+    // SAFETY: A null buffer requests the required socket count.
+    check_status(unsafe { ffi::amdsmi_get_socket_handles(&mut count, ptr::null_mut()) })?;
+    let mut handles = vec![ptr::null_mut(); count as usize];
+    if count > 0 {
+        // SAFETY: `handles` has room for the count returned by the first call.
+        check_status(unsafe { ffi::amdsmi_get_socket_handles(&mut count, handles.as_mut_ptr()) })?;
+        handles.truncate(count as usize);
+    }
+    Ok(handles)
+}
+
+fn processor_handles(
+    socket: ffi::AmdsmiSocketHandle,
+) -> Result<Vec<ffi::AmdsmiProcessorHandle>, ZeusdError> {
+    let mut count = 0;
+    // SAFETY: A null buffer requests the required processor count.
+    check_status(unsafe {
+        ffi::amdsmi_get_processor_handles(socket, &mut count, ptr::null_mut())
+    })?;
+    let mut handles = vec![ptr::null_mut(); count as usize];
+    if count > 0 {
+        // SAFETY: `handles` has room for the count returned by the first call.
+        check_status(unsafe {
+            ffi::amdsmi_get_processor_handles(socket, &mut count, handles.as_mut_ptr())
+        })?;
+        handles.truncate(count as usize);
+    }
+    Ok(handles)
+}
+
+fn enumerate_gpus() -> Result<Vec<ffi::AmdsmiProcessorHandle>, ZeusdError> {
+    init_amdsmi()?;
+    let mut handles = Vec::new();
+    for socket in socket_handles()? {
+        handles.extend(processor_handles(socket)?);
+    }
+    Ok(handles)
+}
+
+fn power_info(handle: ffi::AmdsmiProcessorHandle) -> Result<ffi::AmdsmiPowerInfo, ZeusdError> {
+    let mut info = MaybeUninit::zeroed();
+    // SAFETY: `info` points to writable storage for the output structure.
+    check_status(unsafe { ffi::amdsmi_get_power_info(handle, info.as_mut_ptr()) })?;
+    // SAFETY: AMD SMI initialized the output structure after returning success.
+    Ok(unsafe { info.assume_init() })
+}
+
+fn power_cap_info(
+    handle: ffi::AmdsmiProcessorHandle,
+) -> Result<ffi::AmdsmiPowerCapInfo, ZeusdError> {
+    let mut info = MaybeUninit::zeroed();
+    // SAFETY: `info` points to writable storage for the output structure.
+    check_status(unsafe { ffi::amdsmi_get_power_cap_info(handle, 0, info.as_mut_ptr()) })?;
+    // SAFETY: AMD SMI initialized the output structure after returning success.
+    Ok(unsafe { info.assume_init() })
+}
+
+fn clock_info(
+    handle: ffi::AmdsmiProcessorHandle,
+    clock_type: u32,
+) -> Result<ffi::AmdsmiClkInfo, ZeusdError> {
+    let mut info = MaybeUninit::zeroed();
+    // SAFETY: `info` points to writable storage for the output structure.
+    check_status(unsafe { ffi::amdsmi_get_clock_info(handle, clock_type, info.as_mut_ptr()) })?;
+    // SAFETY: AMD SMI initialized the output structure after returning success.
+    Ok(unsafe { info.assume_init() })
+}
+
+impl AmdsmiGpu {
+    /// Initialize an AMD SMI handle for a GPU index.
+    pub fn init(index: u32) -> Result<Self, ZeusdError> {
+        let handles = enumerate_gpus()?;
+        let handle = handles
+            .get(index as usize)
+            .copied()
+            .ok_or(ZeusdError::GpuNotFoundError(index as usize))?;
+        let power = power_info(handle)?;
+        let power_reading = if power.current_socket_power != u32::MAX {
+            PowerReading::Current
+        } else if power.average_socket_power != u32::MAX {
+            PowerReading::Average
+        } else {
+            PowerReading::Unsupported
+        };
+        tracing::info!(
+            "AMD SMI GPU {} power reading selected: {:?}",
+            index,
+            power_reading
+        );
+
+        let gpu = Self {
+            handle,
+            power_reading,
+        };
+        let name = gpu.name()?;
+        let bdf = gpu.bdf()?;
+        tracing::info!(
+            "Initialized AMD SMI for GPU {} ({}, BDF {})",
+            index,
+            name,
+            bdf
+        );
+        Ok(gpu)
+    }
+
+    /// Read the GPU market name.
+    pub fn name(&self) -> Result<String, ZeusdError> {
+        let mut info = MaybeUninit::zeroed();
+        // SAFETY: `info` points to writable storage for the output structure.
+        check_status(unsafe { ffi::amdsmi_get_gpu_asic_info(self.handle, info.as_mut_ptr()) })?;
+        // SAFETY: AMD SMI initialized the output structure after returning success.
+        let info = unsafe { info.assume_init() };
+        let end = info
+            .market_name
+            .iter()
+            .position(|&character| character == 0)
+            .unwrap_or(info.market_name.len());
+        let bytes: Vec<u8> = info.market_name[..end]
+            .iter()
+            .map(|&character| character as u8)
+            .collect();
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// Read the GPU PCI bus, device, and function identifier.
+    pub fn bdf(&self) -> Result<ffi::Bdf, ZeusdError> {
+        let mut bdf = MaybeUninit::zeroed();
+        // SAFETY: `bdf` points to writable storage for the output value.
+        check_status(unsafe { ffi::amdsmi_get_gpu_device_bdf(self.handle, bdf.as_mut_ptr()) })?;
+        // SAFETY: AMD SMI initialized the output value after returning success.
+        Ok(unsafe { bdf.assume_init() })
+    }
+
+    fn set_locked_clocks(
+        &self,
+        clock_type: u32,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
+        check_status(unsafe {
+            ffi::amdsmi_set_gpu_clk_limit(
+                self.handle,
+                clock_type,
+                ffi::AMDSMI_CLK_LIMIT_MIN,
+                u64::from(min_clock_mhz),
+            )
+        })?;
+        // SAFETY: `self.handle` is a valid process-wide AMD SMI processor handle.
+        check_status(unsafe {
+            ffi::amdsmi_set_gpu_clk_limit(
+                self.handle,
+                clock_type,
+                ffi::AMDSMI_CLK_LIMIT_MAX,
+                u64::from(max_clock_mhz),
+            )
+        })
+    }
+
+    fn reset_locked_clocks(&self, clock_type: u32) -> Result<(), ZeusdError> {
+        let info = clock_info(self.handle, clock_type)?;
+        self.set_locked_clocks(clock_type, info.min_clk, info.max_clk)
+    }
+}
+
+impl GpuManager for AmdsmiGpu {
+    fn device_count() -> Result<u32, ZeusdError> {
+        Ok(enumerate_gpus()?.len() as u32)
+    }
+
+    fn set_persistence_mode(&mut self, _enabled: bool) -> Result<(), ZeusdError> {
+        Err(ZeusdError::InvalidRequest(
+            "persistence mode is not supported on AMD GPUs".into(),
+        ))
+    }
+
+    fn get_persistence_mode(&mut self) -> Result<bool, ZeusdError> {
+        Err(ZeusdError::InvalidRequest(
+            "persistence mode is not supported on AMD GPUs".into(),
+        ))
+    }
+
+    fn set_power_management_limit(&mut self, power_limit_mw: u32) -> Result<(), ZeusdError> {
+        // SAFETY: `self.handle` is valid and AMD SMI accepts the cap in uW.
+        check_status(unsafe {
+            ffi::amdsmi_set_power_cap(self.handle, 0, u64::from(power_limit_mw) * 1000)
+        })
+    }
+
+    fn get_power_management_limit(&mut self) -> Result<u32, ZeusdError> {
+        Ok((power_cap_info(self.handle)?.power_cap / 1000) as u32)
+    }
+
+    fn get_power_management_limit_constraints(&mut self) -> Result<(u32, u32), ZeusdError> {
+        let info = power_cap_info(self.handle)?;
+        Ok((
+            (info.min_power_cap / 1000) as u32,
+            (info.max_power_cap / 1000) as u32,
+        ))
+    }
+
+    fn set_gpu_locked_clocks(
+        &mut self,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        self.set_locked_clocks(ffi::AMDSMI_CLK_TYPE_GFX, min_clock_mhz, max_clock_mhz)
+    }
+
+    fn reset_gpu_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.reset_locked_clocks(ffi::AMDSMI_CLK_TYPE_GFX)
+    }
+
+    fn set_mem_locked_clocks(
+        &mut self,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        self.set_locked_clocks(ffi::AMDSMI_CLK_TYPE_MEM, min_clock_mhz, max_clock_mhz)
+    }
+
+    fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.reset_locked_clocks(ffi::AMDSMI_CLK_TYPE_MEM)
+    }
+
+    fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {
+        let info = power_info(self.handle)?;
+        let power_w = match self.power_reading {
+            PowerReading::Current => info.current_socket_power,
+            PowerReading::Average => info.average_socket_power,
+            PowerReading::Unsupported => {
+                return Err(amdsmi_error(ffi::AMDSMI_STATUS_NOT_SUPPORTED));
+            }
+        };
+        if power_w == u32::MAX {
+            return Err(amdsmi_error(ffi::AMDSMI_STATUS_NOT_SUPPORTED));
+        }
+        Ok(power_w * 1000)
+    }
+
+    fn get_total_energy_consumption(&mut self) -> Result<u64, ZeusdError> {
+        let mut energy_accumulator = 0;
+        let mut counter_resolution = 0.0;
+        let mut timestamp = 0;
+        // SAFETY: All output pointers refer to writable values of the expected types.
+        check_status(unsafe {
+            ffi::amdsmi_get_energy_count(
+                self.handle,
+                &mut energy_accumulator,
+                &mut counter_resolution,
+                &mut timestamp,
+            )
+        })?;
+        Ok((energy_accumulator as f64 * counter_resolution as f64 / 1000.0) as u64)
+    }
+}

--- a/zeusd/src/devices/gpu/mod.rs
+++ b/zeusd/src/devices/gpu/mod.rs
@@ -56,6 +56,8 @@ pub trait GpuManager {
     ) -> Result<(), ZeusdError>;
     /// Reset the memory locked clocks.
     fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError>;
+    /// Reset locked clocks for all clock domains.
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError>;
     /// Read instantaneous power draw in milliwatts.
     fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError>;
     /// Get total energy consumption since driver load in millijoules.
@@ -218,6 +220,8 @@ pub enum GpuCommand {
     },
     /// Reset the GPU's memory locked clocks.
     ResetMemLockedClocks,
+    /// Reset locked clocks for all clock domains.
+    ResetLockedClocks,
     /// Get total energy consumption since driver load.
     GetTotalEnergyConsumption,
     /// Read instantaneous power draw in milliwatts.
@@ -341,6 +345,17 @@ impl GpuCommand {
                     command_start_time,
                     "Memory locked clocks reset",
                     "Cannot reset memory locked clocks",
+                );
+                result.map(|_| GpuResponse::Ok)
+            }
+            Self::ResetLockedClocks => {
+                let result = device.reset_locked_clocks();
+                log_command_result(
+                    &result,
+                    request_arrival_time,
+                    command_start_time,
+                    "All locked clocks reset",
+                    "Cannot reset locked clocks",
                 );
                 result.map(|_| GpuResponse::Ok)
             }

--- a/zeusd/src/devices/gpu/mod.rs
+++ b/zeusd/src/devices/gpu/mod.rs
@@ -4,6 +4,10 @@
 mod nvml;
 #[cfg(feature = "nvml")]
 pub use nvml::NvmlGpu;
+#[cfg(feature = "amdsmi")]
+pub mod amdsmi;
+#[cfg(feature = "amdsmi")]
+pub use amdsmi::AmdsmiGpu;
 
 pub mod power;
 
@@ -106,6 +110,13 @@ pub struct GpuManagementTasks {
 }
 
 impl GpuManagementTasks {
+    /// Create an empty collection of GPU management tasks.
+    pub fn empty() -> Self {
+        Self {
+            senders: Vec::new(),
+        }
+    }
+
     /// Start GPU management tasks for the given GPUs.
     /// It's generic over the type of GPU manager to allow for testing.
     pub fn start<T>(gpus: Vec<T>) -> Result<Self, ZeusdError>

--- a/zeusd/src/devices/gpu/nvml.rs
+++ b/zeusd/src/devices/gpu/nvml.rs
@@ -153,6 +153,16 @@ impl GpuManager for NvmlGpu<'static> {
     }
 
     #[inline]
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        // Attempt both resets regardless of individual failures so one domain
+        // failing does not leave the other locked; report the first error.
+        let gpu_result = self.device.reset_gpu_locked_clocks();
+        let mem_result = self.device.reset_mem_locked_clocks();
+        gpu_result?;
+        Ok(mem_result?)
+    }
+
+    #[inline]
     fn get_total_energy_consumption(&mut self) -> Result<u64, ZeusdError> {
         Ok(self.device.total_energy_consumption()?)
     }

--- a/zeusd/src/error.rs
+++ b/zeusd/src/error.rs
@@ -8,6 +8,10 @@
 
 use std::collections::HashMap;
 
+#[cfg(feature = "amdsmi")]
+use crate::devices::gpu::amdsmi::ffi::{
+    AMDSMI_STATUS_INVAL, AMDSMI_STATUS_NOT_SUPPORTED, AMDSMI_STATUS_NO_PERM,
+};
 use actix_web::http::StatusCode;
 use actix_web::{HttpResponse, ResponseError};
 #[cfg(feature = "nvml")]
@@ -28,6 +32,9 @@ pub enum ZeusdError {
     #[cfg(feature = "nvml")]
     #[error("NVML error: {0}")]
     NvmlError(#[from] NvmlError),
+    #[cfg(feature = "amdsmi")]
+    #[error("AMDSMI error {status}: {msg}")]
+    AmdSmiError { status: u32, msg: String },
     #[error("GPU command send error: {0}")]
     GpuCommandSendError(#[from] SendError<GpuCommandRequest>),
     #[error("CPU command send error: {0}")]
@@ -62,6 +69,12 @@ impl ResponseError for ZeusdError {
                 NvmlError::NoPermission => StatusCode::FORBIDDEN,
                 NvmlError::InvalidArg => StatusCode::BAD_REQUEST,
                 NvmlError::NotSupported => StatusCode::BAD_REQUEST,
+                _ => StatusCode::INTERNAL_SERVER_ERROR,
+            },
+            #[cfg(feature = "amdsmi")]
+            ZeusdError::AmdSmiError { status, .. } => match *status {
+                AMDSMI_STATUS_NO_PERM => StatusCode::FORBIDDEN,
+                AMDSMI_STATUS_INVAL | AMDSMI_STATUS_NOT_SUPPORTED => StatusCode::BAD_REQUEST,
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
             },
             ZeusdError::GpuCommandSendError(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/zeusd/src/lib.rs
+++ b/zeusd/src/lib.rs
@@ -1,5 +1,8 @@
 //! Zeus daemon library.
 
+#[cfg(all(feature = "amdsmi", not(target_os = "linux")))]
+compile_error!("the amdsmi feature is only supported on Linux");
+
 pub mod auth;
 pub mod config;
 pub mod devices;

--- a/zeusd/src/main.rs
+++ b/zeusd/src/main.rs
@@ -10,8 +10,9 @@ use zeusd::routes::DiscoveryInfo;
 #[cfg(windows)]
 use zeusd::startup::run_server_named_pipe;
 use zeusd::startup::{
-    check_privileges, init_tracing, start_cpu_device_tasks, start_cpu_power_poller,
-    start_gpu_device_tasks, start_gpu_power_poller, start_server_tcp, EnabledGroups, ServerState,
+    check_privileges, init_tracing, resolve_gpu_backend, start_cpu_device_tasks,
+    start_cpu_power_poller, start_gpu_device_tasks, start_gpu_power_poller, start_server_tcp,
+    EnabledGroups, ServerState,
 };
 #[cfg(unix)]
 use zeusd::startup::{get_unix_listener, start_server_uds};
@@ -55,6 +56,12 @@ fn handle_token_command(action: TokenCommand) -> anyhow::Result<()> {
 async fn handle_serve(config: zeusd::config::ServeConfig) -> anyhow::Result<()> {
     tracing::info!("Loaded {:?}", config);
 
+    let resolved_gpu_backend = if config.needs_gpu() {
+        Some(resolve_gpu_backend(config.gpu_backend)?)
+    } else {
+        None
+    };
+
     // Validate privileges for the requested API groups.
     check_privileges(&config.enable)?;
 
@@ -91,9 +98,10 @@ async fn handle_serve(config: zeusd::config::ServeConfig) -> anyhow::Result<()> 
 
     // Conditionally initialize GPU devices.
     let (gpu_device_tasks, gpu_power_broadcast, gpus) = if config.needs_gpu() {
-        let (tasks, gpus) = start_gpu_device_tasks()?;
+        let backend = resolved_gpu_backend.expect("GPU backend must be resolved");
+        let (tasks, gpus) = start_gpu_device_tasks(backend)?;
         let broadcast = if config.is_enabled(ApiGroup::GpuRead) {
-            Some(start_gpu_power_poller(config.gpu_power_poll_hz)?)
+            Some(start_gpu_power_poller(backend, config.gpu_power_poll_hz)?)
         } else {
             None
         };

--- a/zeusd/src/routes/gpu.rs
+++ b/zeusd/src/routes/gpu.rs
@@ -160,6 +160,8 @@ impl_write_handler_for_gpu_command!(
 
 impl_write_handler_for_gpu_command!(reset_mem_locked_clocks, "/reset_mem_locked_clocks",);
 
+impl_write_handler_for_gpu_command!(reset_locked_clocks, "/reset_locked_clocks",);
+
 /// Macro for a read endpoint that fans a `GpuCommand` out to each requested
 /// GPU and returns a JSON map keyed by GPU id.
 ///
@@ -360,5 +362,6 @@ pub fn gpu_control_routes(cfg: &mut web::ServiceConfig) {
         .service(set_gpu_locked_clocks_handler)
         .service(reset_gpu_locked_clocks_handler)
         .service(set_mem_locked_clocks_handler)
-        .service(reset_mem_locked_clocks_handler);
+        .service(reset_mem_locked_clocks_handler)
+        .service(reset_locked_clocks_handler);
 }

--- a/zeusd/src/startup.rs
+++ b/zeusd/src/startup.rs
@@ -21,19 +21,23 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::{EnvFilter, Registry};
 
 use crate::auth::{AuthMiddleware, SigningKeyData};
-use crate::config::ApiGroup;
+use crate::config::{ApiGroup, GpuBackend};
 #[cfg(target_os = "linux")]
 use crate::devices::cpu::power::start_cpu_poller;
 use crate::devices::cpu::power::CpuPowerBroadcasts;
 use crate::devices::cpu::CpuManagementTasks;
 #[cfg(target_os = "linux")]
 use crate::devices::cpu::{CpuManager, RaplCpu};
-#[cfg(feature = "nvml")]
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
 use crate::devices::gpu::power::start_gpu_poller;
 use crate::devices::gpu::power::GpuPowerBroadcasts;
+#[cfg(feature = "amdsmi")]
+use crate::devices::gpu::AmdsmiGpu;
 use crate::devices::gpu::GpuManagementTasks;
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
+use crate::devices::gpu::GpuManager;
 #[cfg(feature = "nvml")]
-use crate::devices::gpu::{GpuManager, NvmlGpu};
+use crate::devices::gpu::NvmlGpu;
 use crate::routes::{cpu_routes, CpuPowerSamplingPeriod};
 use crate::routes::{
     gpu_control_routes, gpu_read_routes, server_routes, CpuDiscoveryInfo, DiscoveryInfo,
@@ -83,17 +87,126 @@ pub fn get_unix_listener(
     Ok(listener)
 }
 
-/// Initialize NVML and start GPU management tasks.
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
+trait StartupGpu: GpuManager + Send + Sized + 'static {
+    fn init(index: u32) -> Result<Self, crate::error::ZeusdError>;
+    fn name(&self) -> Result<String, crate::error::ZeusdError>;
+}
+
 #[cfg(feature = "nvml")]
-pub fn start_gpu_device_tasks() -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
-    tracing::info!("Starting NVML and GPU management tasks.");
-    let num_gpus = NvmlGpu::device_count()?;
+impl StartupGpu for NvmlGpu<'static> {
+    fn init(index: u32) -> Result<Self, crate::error::ZeusdError> {
+        NvmlGpu::init(index)
+    }
+
+    fn name(&self) -> Result<String, crate::error::ZeusdError> {
+        NvmlGpu::name(self)
+    }
+}
+
+#[cfg(feature = "amdsmi")]
+impl StartupGpu for AmdsmiGpu {
+    fn init(index: u32) -> Result<Self, crate::error::ZeusdError> {
+        AmdsmiGpu::init(index)
+    }
+
+    fn name(&self) -> Result<String, crate::error::ZeusdError> {
+        AmdsmiGpu::name(self)
+    }
+}
+
+/// A GPU backend available in this build, or no backend when none reports GPUs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ResolvedGpuBackend {
+    #[cfg(feature = "nvml")]
+    Nvml,
+    #[cfg(feature = "amdsmi")]
+    Amdsmi,
+    None,
+}
+
+/// Resolve a requested backend according to compiled features and GPU discovery.
+pub fn resolve_gpu_backend(requested: GpuBackend) -> anyhow::Result<ResolvedGpuBackend> {
+    match requested {
+        GpuBackend::Nvml => {
+            #[cfg(feature = "nvml")]
+            {
+                let count = NvmlGpu::device_count()?;
+                tracing::info!("NVML backend was selected with {} GPU(s)", count);
+                Ok(ResolvedGpuBackend::Nvml)
+            }
+            #[cfg(not(feature = "nvml"))]
+            {
+                anyhow::bail!(
+                    "this zeusd binary was built without the NVML backend; rebuild with --features nvml"
+                )
+            }
+        }
+        GpuBackend::Amdsmi => {
+            #[cfg(feature = "amdsmi")]
+            {
+                let count = AmdsmiGpu::device_count()?;
+                tracing::info!("AMDSMI backend was selected with {} GPU(s)", count);
+                Ok(ResolvedGpuBackend::Amdsmi)
+            }
+            #[cfg(not(feature = "amdsmi"))]
+            {
+                anyhow::bail!(
+                    "this zeusd binary was built without the AMDSMI backend; rebuild with --features amdsmi"
+                )
+            }
+        }
+        GpuBackend::Auto => {
+            #[cfg(feature = "nvml")]
+            let nvml_count = NvmlGpu::device_count()?;
+            #[cfg(not(feature = "nvml"))]
+            let nvml_count = 0;
+
+            #[cfg(feature = "amdsmi")]
+            let amdsmi_count = match AmdsmiGpu::device_count() {
+                Ok(count) => count,
+                Err(error) => {
+                    tracing::warn!(
+                        "AMDSMI backend probe failed: {}. Treating it as zero GPUs.",
+                        error
+                    );
+                    0
+                }
+            };
+            #[cfg(not(feature = "amdsmi"))]
+            let amdsmi_count = 0;
+
+            if nvml_count > 0 && amdsmi_count > 0 {
+                anyhow::bail!("both NVIDIA and AMD GPUs detected; pick one with --gpu-backend");
+            }
+            if nvml_count > 0 {
+                tracing::info!("NVML backend was selected with {} GPU(s)", nvml_count);
+                #[cfg(feature = "nvml")]
+                return Ok(ResolvedGpuBackend::Nvml);
+            }
+            if amdsmi_count > 0 {
+                tracing::info!("AMDSMI backend was selected with {} GPU(s)", amdsmi_count);
+                #[cfg(feature = "amdsmi")]
+                return Ok(ResolvedGpuBackend::Amdsmi);
+            }
+            tracing::info!("No GPU backend reported any GPUs");
+            Ok(ResolvedGpuBackend::None)
+        }
+    }
+}
+
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
+fn start_gpu_device_tasks_for<T: StartupGpu>(
+    backend_name: &str,
+) -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
+    tracing::info!("Starting {} and GPU management tasks.", backend_name);
+    let num_gpus = T::device_count()?;
     let mut gpus = Vec::with_capacity(num_gpus as usize);
     let mut gpu_info = Vec::with_capacity(num_gpus as usize);
     for gpu_id in 0..num_gpus {
-        let gpu = NvmlGpu::init(gpu_id)?;
+        let gpu = T::init(gpu_id)?;
         let name = gpu.name()?;
-        tracing::info!("Initialized NVML for GPU {} ({})", gpu_id, name);
+        tracing::info!("Initialized {} for GPU {} ({})", backend_name, gpu_id, name);
         gpu_info.push(GpuDiscoveryInfo {
             id: gpu_id as usize,
             name,
@@ -103,33 +216,44 @@ pub fn start_gpu_device_tasks() -> anyhow::Result<(GpuManagementTasks, Vec<GpuDi
     Ok((GpuManagementTasks::start(gpus)?, gpu_info))
 }
 
-#[cfg(not(feature = "nvml"))]
-pub fn start_gpu_device_tasks() -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
-    anyhow::bail!(
-        "This zeusd binary was built without a GPU backend. \
-         Rebuild with --features nvml, or remove 'gpu-control' and 'gpu-read' from --enable."
-    )
+/// Initialize the resolved backend and start GPU management tasks.
+pub fn start_gpu_device_tasks(
+    backend: ResolvedGpuBackend,
+) -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
+    match backend {
+        #[cfg(feature = "nvml")]
+        ResolvedGpuBackend::Nvml => start_gpu_device_tasks_for::<NvmlGpu<'static>>("NVML"),
+        #[cfg(feature = "amdsmi")]
+        ResolvedGpuBackend::Amdsmi => start_gpu_device_tasks_for::<AmdsmiGpu>("AMD SMI"),
+        ResolvedGpuBackend::None => Ok((GpuManagementTasks::empty(), Vec::new())),
+    }
 }
 
-/// Initialize a separate set of NVML handles and start the GPU power poller.
-#[cfg(feature = "nvml")]
-pub fn start_gpu_power_poller(poll_hz: u32) -> anyhow::Result<GpuPowerBroadcasts> {
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
+fn start_gpu_power_poller_for<T: StartupGpu>(poll_hz: u32) -> anyhow::Result<GpuPowerBroadcasts> {
     tracing::info!("Starting GPU power poller at {} Hz.", poll_hz);
-    let num_gpus = NvmlGpu::device_count()?;
+    let num_gpus = T::device_count()?;
     let mut gpus = Vec::with_capacity(num_gpus as usize);
     for gpu_id in 0..num_gpus {
-        let gpu = NvmlGpu::init(gpu_id)?;
+        let gpu = T::init(gpu_id)?;
         gpus.push((gpu_id as usize, gpu));
     }
     Ok(start_gpu_poller(gpus, poll_hz))
 }
 
-#[cfg(not(feature = "nvml"))]
-pub fn start_gpu_power_poller(_poll_hz: u32) -> anyhow::Result<GpuPowerBroadcasts> {
-    anyhow::bail!(
-        "This zeusd binary was built without a GPU backend. \
-         Rebuild with --features nvml, or remove 'gpu-control' and 'gpu-read' from --enable."
-    )
+/// Initialize separate handles for the resolved backend and start power polling.
+pub fn start_gpu_power_poller(
+    backend: ResolvedGpuBackend,
+    poll_hz: u32,
+) -> anyhow::Result<GpuPowerBroadcasts> {
+    let _ = poll_hz;
+    match backend {
+        #[cfg(feature = "nvml")]
+        ResolvedGpuBackend::Nvml => start_gpu_power_poller_for::<NvmlGpu<'static>>(poll_hz),
+        #[cfg(feature = "amdsmi")]
+        ResolvedGpuBackend::Amdsmi => start_gpu_power_poller_for::<AmdsmiGpu>(poll_hz),
+        ResolvedGpuBackend::None => Ok(GpuPowerBroadcasts::new(Default::default())),
+    }
 }
 
 /// Initialize RAPL and start CPU management tasks.
@@ -189,14 +313,17 @@ pub fn start_cpu_power_poller(_poll_hz: u32) -> anyhow::Result<CpuPowerBroadcast
 /// daemon lacks the privileges for.
 #[allow(unused_variables)]
 pub fn check_privileges(enabled_groups: &[ApiGroup]) -> anyhow::Result<()> {
-    #[cfg(all(not(target_os = "linux"), not(feature = "nvml")))]
+    #[cfg(all(
+        not(target_os = "linux"),
+        not(any(feature = "nvml", feature = "amdsmi"))
+    ))]
     {
         if enabled_groups.is_empty() {
             anyhow::bail!("No API groups are enabled. Specify at least one group with --enable.");
         }
     }
 
-    #[cfg(not(feature = "nvml"))]
+    #[cfg(not(any(feature = "nvml", feature = "amdsmi")))]
     {
         if enabled_groups.contains(&ApiGroup::GpuControl)
             || enabled_groups.contains(&ApiGroup::GpuRead)
@@ -204,7 +331,8 @@ pub fn check_privileges(enabled_groups: &[ApiGroup]) -> anyhow::Result<()> {
             tracing::error!("GPU API groups require a zeusd binary built with a GPU backend.");
             anyhow::bail!(
                 "This zeusd binary was built without a GPU backend. \
-                 Rebuild with --features nvml, or remove 'gpu-control' and 'gpu-read' from --enable."
+                 Rebuild with --features nvml or --features amdsmi, or remove 'gpu-control' and \
+                 'gpu-read' from --enable."
             );
         }
     }

--- a/zeusd/src/startup.rs
+++ b/zeusd/src/startup.rs
@@ -158,7 +158,16 @@ pub fn resolve_gpu_backend(requested: GpuBackend) -> anyhow::Result<ResolvedGpuB
         }
         GpuBackend::Auto => {
             #[cfg(feature = "nvml")]
-            let nvml_count = NvmlGpu::device_count()?;
+            let nvml_count = match NvmlGpu::device_count() {
+                Ok(count) => count,
+                Err(error) => {
+                    tracing::warn!(
+                        "NVML backend probe failed: {}. Treating it as zero GPUs.",
+                        error
+                    );
+                    0
+                }
+            };
             #[cfg(not(feature = "nvml"))]
             let nvml_count = 0;
 

--- a/zeusd/tests/gpu.rs
+++ b/zeusd/tests/gpu.rs
@@ -10,8 +10,8 @@ use zeusd::devices::gpu::power::start_gpu_poller;
 use zeusd::devices::gpu::GpuManager;
 use zeusd::error::ZeusdError;
 use zeusd::routes::gpu::{
-    ResetGpuLockedClocks, ResetMemLockedClocks, SetGpuLockedClocks, SetMemLockedClocks,
-    SetPersistenceMode, SetPowerLimit,
+    ResetGpuLockedClocks, ResetLockedClocks, ResetMemLockedClocks, SetGpuLockedClocks,
+    SetMemLockedClocks, SetPersistenceMode, SetPowerLimit,
 };
 
 use crate::helpers::{TestApp, NUM_GPUS};
@@ -724,6 +724,23 @@ async fn test_mem_locked_clocks_bulk() {
 }
 
 #[tokio::test]
+async fn test_reset_locked_clocks() {
+    let mut app = TestApp::start().await;
+
+    let resp = app
+        .send(ResetLockedClocks {
+            gpu_ids: "0".to_string(),
+            block: true,
+        })
+        .await
+        .expect("Failed to send request");
+
+    assert_eq!(resp.status(), 200);
+    assert_eq!(app.gpu_locked_clocks_history_for_gpu(0), vec![(0, 0)]);
+    assert_eq!(app.mem_locked_clocks_history_for_gpu(0), vec![(0, 0)]);
+}
+
+#[tokio::test]
 async fn test_gpu_cumulative_energy() {
     let _app = TestApp::start().await;
     let client = reqwest::Client::new();
@@ -986,6 +1003,9 @@ impl GpuManager for PollCountingGpu {
         Ok(())
     }
     fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        Ok(())
+    }
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
         Ok(())
     }
     fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {

--- a/zeusd/tests/helpers/mod.rs
+++ b/zeusd/tests/helpers/mod.rs
@@ -144,6 +144,12 @@ impl GpuManager for TestGpu {
         Ok(())
     }
 
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.gpu_locked_clocks_tx.send((0, 0)).unwrap();
+        self.mem_locked_clocks_tx.send((0, 0)).unwrap();
+        Ok(())
+    }
+
     fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {
         Ok(150_000)
     }
@@ -389,6 +395,7 @@ impl_zeusd_request_gpu!(SetGpuLockedClocks);
 impl_zeusd_request_gpu!(ResetGpuLockedClocks);
 impl_zeusd_request_gpu!(SetMemLockedClocks);
 impl_zeusd_request_gpu!(ResetMemLockedClocks);
+impl_zeusd_request_gpu!(ResetLockedClocks);
 
 impl_zeusd_request_cpu!(GetCumulativeEnergy);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Linux AMD GPU support through AMD SMI and ROCm.
  - Added automatic or explicit GPU backend selection for NVIDIA and AMD hardware.
  - Added an endpoint to reset locked GPU and memory clocks across all domains.
  - Added AMD telemetry, power management, clock control, and device discovery.

- **Documentation**
  - Updated installation and platform guidance with ROCm requirements and AMD configuration steps.

- **Tests**
  - Added coverage for AMD builds, backend behavior, clock resets, and GPU controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->