### PR TITLE
[Zeusd] NVIDIA & AMD GPU discovery with PCIe ID

### DIFF
--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -96,27 +96,35 @@ zeusd token issue --signing-key-path /etc/zeusd/signing.key \
 
 `--expires` accepts `1h`, `7d`, `30d`, or `never`. Hand the token to applications via `ZEUSD_TOKEN`, or `-H "Authorization: Bearer ..."` for curl. `/discover` and `/time` never require auth.
 
-## Windows quirk
+## Notes on Platforms
+
+### Windows
 
 NVML's persistence-mode API is Linux-only. On Windows the kernel driver is always loaded, so `POST /gpu/set_persistence_mode?enabled=true` is a 200 no-op (logged once); `enabled=false` returns 400. All other GPU operations behave identically across platforms.
 
-## AMD GPU notes
+### NVIDIA GPU
+
+The cumulative energy counter requires Volta or newer.
+On older GPUs, `cumulative_energy_available` is false in `/discover` and `GET /gpu/get_cumulative_energy` returns 400.
+
+### AMD GPU
 
 GPU indices follow PCI bus order sorted by PCI address, which is the same order used by the `amd-smi` CLI.
 The reported GPU name is AMD SMI's market name and can differ across ROCm versions for the same GPU.
 
-On some AMD GPUs, the driver's cumulative energy counter advances at the wrong rate; see [ROCm/amdsmi issue 38](https://github.com/ROCm/amdsmi/issues/38).
+On some AMD GPUs, the driver's cumulative energy counter advances at the wrong rate; see [ROCm/amdsmi #38](https://github.com/ROCm/amdsmi/issues/38).
 At startup, `zeusd` integrates power over 0.5 seconds, compares it with the counter delta, and marks GPUs that fail validation as `cumulative_energy_available: false`.
 
-MI250 and MI250X are dual-die GPUs, and the driver reports the combined power of both dies on the even-indexed die and nothing on the odd-indexed die.
-Power and energy for the odd die are unavailable or zero, while the even die's readings cover both dies.
+MI250 and MI250X are dual-die GPUs, and from AMD SMI, each die looks like an individual GPU, one even indexed and the other odd indexed.
+The driver reports the combined power of both dies on the even-indexed die, and nothing (either unavailable or zero) on the odd-indexed die.
 
-Per AMD SMI's platform support, clock locking and the energy counter work only on bare-metal Linux, and power capping is unavailable on most guest types.
+Per AMD SMI's platform support, clock locking and the energy counter work only on bare-metal Linux.
+Power capping additionally works on virtualization hosts and single-VF (SR-IOV) guests, but not on multi-VF or Windows guests.
 On virtualized AMD GPUs, these operations return 400.
 
-AMD GPU control writes go through the amdgpu driver's sysfs files, so systemd's `ProtectKernelTunables=true` (which mounts `/sys` read-only) breaks them.
-The unit shipped in `zeusd/packaging/systemd/` leaves it off so AMD control works out of the box; if you run zeusd under your own hardened unit, make sure that directive is not set (see the [systemd packaging README](https://github.com/ml-energy/zeus/tree/master/zeusd/packaging/systemd#amd-gpus){.external}).
-When ROCm is outside the default search locations, set `ROCM_PATH` or `AMDSMI_LIB_DIR` in `/etc/default/zeusd`.
+When ROCm is outside the default search locations, point the daemon at it in `/etc/default/zeusd`.
+`ROCM_PATH` is a ROCm installation root whose `lib/` contains `libamd_smi.so.<abi>`, e.g., `ROCM_PATH=/opt/rocm-7.2.0`.
+`AMDSMI_LIB_DIR` is any directory that directly contains `libamd_smi.so.<abi>`, e.g., `AMDSMI_LIB_DIR=/opt/rocm-7.2.0/lib`.
 
 ## Troubleshooting
 
@@ -124,7 +132,6 @@ When ROCm is outside the default search locations, set `ROCM_PATH` or `AMDSMI_LI
 - **`Permission denied` on the UDS socket.** Clients need write access. The default `--socket-permissions 666` grants everyone; use `--socket-uid`/`--socket-gid` to scope tighter.
 - **Daemon exits immediately at startup.** On Linux, a root-required group is enabled but `zeusd` isn't running as root. Either `sudo` or `--enable gpu-read`.
 - **AMD GPUs not detected.** GPU backends are probed once at startup, so `zeusd` must start after the `amdgpu` driver is loaded (order the systemd unit accordingly, or restart the daemon).
-- **AMD GPU control fails under systemd.** If clock or power limit writes fail while the same daemon works when started manually as root, the unit probably sets `ProtectKernelTunables=true`, which blocks amdgpu sysfs writes. The [shipped unit](https://github.com/ml-energy/zeus/tree/master/zeusd/packaging/systemd#amd-gpus){.external} leaves it off.
 - **Logs.** `journalctl -u zeusd -f` under systemd; stderr otherwise.
 
 ## HTTP API reference
@@ -153,9 +160,7 @@ Available devices, capabilities, and enabled API groups. Always available; never
 ```
 
 `pci_address` is the PCI domain:bus:device.function address, formatted as in `lspci -D`.
-`cumulative_energy_available` states whether `GET /gpu/get_cumulative_energy` serves trustworthy values for that GPU, and the endpoint returns 400 for that GPU when the field is false.
-For NVIDIA GPUs, it is false when the driver does not support the total energy counter, as on pre-Volta GPUs.
-For AMD GPUs, it is false when the counter is unsupported or failed the [startup validation](#amd-gpu-notes).
+`cumulative_energy_available` states whether the GPU has a trustworthy cumulative energy counter; when false, `GET /gpu/get_cumulative_energy` returns 400 for that GPU (see [Notes on Platforms](#notes-on-platforms)).
 
 ### `GET /time`
 
@@ -184,7 +189,7 @@ Writes (`POST`) also take `block` (bool): `true` waits for completion and report
 | Method | Path | Extra params / notes |
 |---|---|---|
 | `POST` | `/gpu/set_power_limit` | `power_limit_mw` |
-| `POST` | `/gpu/set_persistence_mode` | `enabled`; AMD GPUs return 400 because persistence mode is an NVML concept (see [Windows quirk](#windows-quirk)). |
+| `POST` | `/gpu/set_persistence_mode` | `enabled`; AMD GPUs return 400 because persistence mode is an NVML concept (see [Windows notes](#windows)). |
 | `POST` | `/gpu/set_gpu_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
 | `POST` | `/gpu/reset_gpu_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
 | `POST` | `/gpu/set_mem_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -100,12 +100,31 @@ zeusd token issue --signing-key-path /etc/zeusd/signing.key \
 
 NVML's persistence-mode API is Linux-only. On Windows the kernel driver is always loaded, so `POST /gpu/set_persistence_mode?enabled=true` is a 200 no-op (logged once); `enabled=false` returns 400. All other GPU operations behave identically across platforms.
 
+## AMD GPU notes
+
+GPU indices follow PCI bus order sorted by PCI address, which is the same order used by the `amd-smi` CLI.
+The reported GPU name is AMD SMI's market name and can differ across ROCm versions for the same GPU.
+
+On some AMD GPUs, the driver's cumulative energy counter advances at the wrong rate; see [ROCm/amdsmi issue 38](https://github.com/ROCm/amdsmi/issues/38).
+At startup, `zeusd` integrates power over 0.5 seconds, compares it with the counter delta, and marks GPUs that fail validation as `cumulative_energy_available: false`.
+
+MI250 and MI250X are dual-die GPUs, and the driver reports the combined power of both dies on the even-indexed die and nothing on the odd-indexed die.
+Power and energy for the odd die are unavailable or zero, while the even die's readings cover both dies.
+
+Per AMD SMI's platform support, clock locking and the energy counter work only on bare-metal Linux, and power capping is unavailable on most guest types.
+On virtualized AMD GPUs, these operations return 400.
+
+AMD GPU control writes go through the amdgpu driver's sysfs files, so systemd's `ProtectKernelTunables=true` (which mounts `/sys` read-only) breaks them.
+The unit shipped in `zeusd/packaging/systemd/` leaves it off so AMD control works out of the box; if you run zeusd under your own hardened unit, make sure that directive is not set (see the [systemd packaging README](https://github.com/ml-energy/zeus/tree/master/zeusd/packaging/systemd#amd-gpus){.external}).
+When ROCm is outside the default search locations, set `ROCM_PATH` or `AMDSMI_LIB_DIR` in `/etc/default/zeusd`.
+
 ## Troubleshooting
 
 - **Python doesn't pick up `zeusd`.** Confirm `ZEUSD_SOCK_PATH` or `ZEUSD_HOST_PORT` is in the *application's* environment (not just the shell that started the daemon). Then run `python -m zeus.show_env`.
 - **`Permission denied` on the UDS socket.** Clients need write access. The default `--socket-permissions 666` grants everyone; use `--socket-uid`/`--socket-gid` to scope tighter.
 - **Daemon exits immediately at startup.** On Linux, a root-required group is enabled but `zeusd` isn't running as root. Either `sudo` or `--enable gpu-read`.
 - **AMD GPUs not detected.** GPU backends are probed once at startup, so `zeusd` must start after the `amdgpu` driver is loaded (order the systemd unit accordingly, or restart the daemon).
+- **AMD GPU control fails under systemd.** If clock or power limit writes fail while the same daemon works when started manually as root, the unit probably sets `ProtectKernelTunables=true`, which blocks amdgpu sysfs writes. The [shipped unit](https://github.com/ml-energy/zeus/tree/master/zeusd/packaging/systemd#amd-gpus){.external} leaves it off.
 - **Logs.** `journalctl -u zeusd -f` under systemd; stderr otherwise.
 
 ## HTTP API reference
@@ -121,8 +140,8 @@ Available devices, capabilities, and enabled API groups. Always available; never
 ```json
 {
   "gpus": [
-    {"id": 0, "name": "NVIDIA A40"},
-    {"id": 1, "name": "NVIDIA A40"}
+    {"id": 0, "name": "NVIDIA A40", "pci_address": "0000:01:00.0", "cumulative_energy_available": true},
+    {"id": 1, "name": "NVIDIA A40", "pci_address": "0000:41:00.0", "cumulative_energy_available": true}
   ],
   "cpus": [
     {"id": 0, "dram_available": true},
@@ -132,6 +151,11 @@ Available devices, capabilities, and enabled API groups. Always available; never
   "auth_required": false
 }
 ```
+
+`pci_address` is the PCI domain:bus:device.function address, formatted as in `lspci -D`.
+`cumulative_energy_available` states whether `GET /gpu/get_cumulative_energy` serves trustworthy values for that GPU, and the endpoint returns 400 for that GPU when the field is false.
+For NVIDIA GPUs, it is false when the driver does not support the total energy counter, as on pre-Volta GPUs.
+For AMD GPUs, it is false when the counter is unsupported or failed the [startup validation](#amd-gpu-notes).
 
 ### `GET /time`
 
@@ -160,18 +184,18 @@ Writes (`POST`) also take `block` (bool): `true` waits for completion and report
 | Method | Path | Extra params / notes |
 |---|---|---|
 | `POST` | `/gpu/set_power_limit` | `power_limit_mw` |
-| `POST` | `/gpu/set_persistence_mode` | `enabled` (see [Windows quirk](#windows-quirk)) |
+| `POST` | `/gpu/set_persistence_mode` | `enabled`; AMD GPUs return 400 because persistence mode is an NVML concept (see [Windows quirk](#windows-quirk)). |
 | `POST` | `/gpu/set_gpu_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
 | `POST` | `/gpu/reset_gpu_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
 | `POST` | `/gpu/set_mem_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
 | `POST` | `/gpu/reset_mem_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
 | `POST` | `/gpu/reset_locked_clocks` | resets all clock domains |
-| `GET`  | `/gpu/get_cumulative_energy` | -- |
+| `GET`  | `/gpu/get_cumulative_energy` | GPUs whose `cumulative_energy_available` is false in `/discover` return 400. |
 | `GET`  | `/gpu/get_power` | one-shot snapshot |
 | `GET`  | `/gpu/stream_power` | SSE stream |
 | `GET`  | `/gpu/get_power_limit` | -- |
 | `GET`  | `/gpu/get_power_limit_constraints` | -- |
-| `GET`  | `/gpu/get_persistence_mode` | always `true` on Windows |
+| `GET`  | `/gpu/get_persistence_mode` | AMD GPUs return 400 because persistence mode is an NVML concept; always `true` on Windows. |
 
 `get_cumulative_energy` response (keyed by GPU index as string):
 

--- a/zeusd/packaging/systemd/README.md
+++ b/zeusd/packaging/systemd/README.md
@@ -35,6 +35,19 @@ ExecStart=/opt/zeusd/bin/zeusd serve $ZEUSD_ARGS
 
 The empty `ExecStart=` line clears the inherited value before redefining it; systemd requires this for `ExecStart`.
 
+## AMD GPUs
+
+AMD GPU control writes clock limits, the power cap, and the performance level through the amdgpu driver's sysfs files.
+The unit therefore ships with `ProtectKernelTunables=false`; setting it to true would mount `/sys` read-only and block those writes.
+NVIDIA control uses `/dev/nvidia*` ioctls and does not care, so NVIDIA-only nodes can re-enable the directive with a drop-in (`sudo systemctl edit zeusd`):
+
+```ini
+[Service]
+ProtectKernelTunables=true
+```
+
+Environment variables such as `ROCM_PATH` or `AMDSMI_LIB_DIR` can be set in `/etc/default/zeusd` because the unit loads it as an `EnvironmentFile`.
+
 ## Verifying
 
 ```sh
@@ -43,4 +56,4 @@ journalctl -u zeusd -f
 systemd-analyze security zeusd.service
 ```
 
-At the time of writing, `zeusd.service`'s systemd exposure level score is 3.1 OK.
+At the time of writing, `zeusd.service`'s systemd exposure level score is 3.5 OK.

--- a/zeusd/packaging/systemd/README.md
+++ b/zeusd/packaging/systemd/README.md
@@ -22,7 +22,7 @@ Default config: UDS mode on `/run/zeusd/zeusd.sock`, all API groups enabled.
 
 Two layers of override, both survive package upgrades:
 
-- **CLI args** -- edit `/etc/default/zeusd` and set `ZEUSD_ARGS=...`, then `sudo systemctl restart zeusd`.
+- **CLI args** -- edit `/etc/default/zeusd` and set `ZEUSD_ARGS=...`, then `sudo systemctl restart zeusd`. The same file is loaded as an `EnvironmentFile`, so runtime environment variables like `ROCM_PATH` or `AMDSMI_LIB_DIR` (AMD SMI library discovery) also go there.
 - **Unit directives** -- `sudo systemctl edit zeusd` opens a drop-in at `/etc/systemd/system/zeusd.service.d/override.conf`. Use this to override `ExecStart=` (e.g., if `zeusd` lives in `/opt/zeusd/bin/`) or to relax a hardening directive. Do not edit the upstream unit in place.
 
 Example drop-in for a non-standard binary path:
@@ -35,18 +35,15 @@ ExecStart=/opt/zeusd/bin/zeusd serve $ZEUSD_ARGS
 
 The empty `ExecStart=` line clears the inherited value before redefining it; systemd requires this for `ExecStart`.
 
-## AMD GPUs
+## Additional hardening
 
-AMD GPU control writes clock limits, the power cap, and the performance level through the amdgpu driver's sysfs files.
-The unit therefore ships with `ProtectKernelTunables=false`; setting it to true would mount `/sys` read-only and block those writes.
-NVIDIA control uses `/dev/nvidia*` ioctls and does not care, so NVIDIA-only nodes can re-enable the directive with a drop-in (`sudo systemctl edit zeusd`):
+The unit ships with `ProtectKernelTunables=false` because AMD GPU control (clock limits, power cap, performance level) writes to the amdgpu driver's sysfs files, which that directive would mount read-only.
+NVIDIA GPU control goes through `/dev/nvidia*` ioctls and is unaffected, so deployments that never use AMD GPU control can harden further with a drop-in (`sudo systemctl edit zeusd`):
 
 ```ini
 [Service]
 ProtectKernelTunables=true
 ```
-
-Environment variables such as `ROCM_PATH` or `AMDSMI_LIB_DIR` can be set in `/etc/default/zeusd` because the unit loads it as an `EnvironmentFile`.
 
 ## Verifying
 
@@ -56,4 +53,4 @@ journalctl -u zeusd -f
 systemd-analyze security zeusd.service
 ```
 
-At the time of writing, `zeusd.service`'s systemd exposure level score is 3.5 OK.
+With systemd 252, `zeusd.service`'s exposure level score is 3.5 OK; the exact number varies across systemd versions.

--- a/zeusd/packaging/systemd/zeusd.service
+++ b/zeusd/packaging/systemd/zeusd.service
@@ -20,7 +20,8 @@ RuntimeDirectoryMode=0755
 # CAP_CHOWN is needed only when --socket-uid/--socket-gid are passed.
 # ProtectKernelTunables stays off because AMD GPU control writes go
 # through the amdgpu driver's sysfs files, which it would mount read-only.
-# NVIDIA-only nodes can re-enable it (see the README's AMD GPUs section).
+# Nodes without AMD GPU control can re-enable it (see the README's
+# Additional hardening section).
 CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH CAP_CHOWN
 NoNewPrivileges=true
 ProtectSystem=strict

--- a/zeusd/packaging/systemd/zeusd.service
+++ b/zeusd/packaging/systemd/zeusd.service
@@ -18,12 +18,15 @@ RuntimeDirectoryMode=0755
 # Even when running as root, CAP_DAC_READ_SEARCH is required to read
 # /sys/class/powercap/.../energy_uj (mode 0400 since CVE-2020-8694).
 # CAP_CHOWN is needed only when --socket-uid/--socket-gid are passed.
+# ProtectKernelTunables stays off because AMD GPU control writes go
+# through the amdgpu driver's sysfs files, which it would mount read-only.
+# NVIDIA-only nodes can re-enable it (see the README's AMD GPUs section).
 CapabilityBoundingSet=CAP_SYS_ADMIN CAP_DAC_READ_SEARCH CAP_CHOWN
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true
-ProtectKernelTunables=true
+ProtectKernelTunables=false
 ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true

--- a/zeusd/src/devices/gpu/amdsmi/mod.rs
+++ b/zeusd/src/devices/gpu/amdsmi/mod.rs
@@ -8,6 +8,7 @@ use std::ffi::{CStr, OsStr};
 use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 use std::ptr;
+use std::time::Duration;
 
 use libloading::Library;
 use once_cell::sync::OnceCell;
@@ -400,11 +401,29 @@ enum PowerReading {
     Unsupported,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum EnergyCounterVerdict {
+    CannotValidate,
+    Reliable,
+    Unreliable,
+}
+
+fn energy_counter_verdict(expected_mj: f64, measured_mj: f64) -> EnergyCounterVerdict {
+    if expected_mj < 0.001 {
+        EnergyCounterVerdict::CannotValidate
+    } else if 0.1 < measured_mj / expected_mj && measured_mj / expected_mj < 10.0 {
+        EnergyCounterVerdict::Reliable
+    } else {
+        EnergyCounterVerdict::Unreliable
+    }
+}
+
 /// A GPU managed through AMD SMI.
 pub struct AmdsmiGpu {
     api: &'static AmdsmiApi,
     handle: ffi::AmdsmiProcessorHandle,
     power_reading: PowerReading,
+    cumulative_energy_available: bool,
     // Single-task ownership serializes cache updates; failed writes requery bounds to cover external changes.
     gfx_clock_bounds: Option<(u32, u32)>,
     mem_clock_bounds: Option<(u32, u32)>,
@@ -590,13 +609,14 @@ impl AmdsmiGpu {
             api,
             handle,
             power_reading,
+            cumulative_energy_available: false,
             gfx_clock_bounds,
             mem_clock_bounds,
         };
         let name = gpu.name()?;
         let bdf = gpu.bdf()?;
         tracing::info!(
-            "Initialized AMD SMI for GPU {} ({}, BDF {})",
+            "Initialized AMD SMI for GPU {} ({}, PCI address {})",
             index,
             name,
             bdf
@@ -634,6 +654,22 @@ impl AmdsmiGpu {
         })?;
         // SAFETY: AMD SMI initialized the output value after returning success.
         Ok(unsafe { bdf.assume_init() })
+    }
+
+    fn raw_total_energy_consumption(&self) -> Result<u64, ZeusdError> {
+        let mut energy_accumulator = 0;
+        let mut counter_resolution = 0.0;
+        let mut timestamp = 0;
+        // SAFETY: All output pointers refer to writable values of the expected types.
+        check_status(self.api, unsafe {
+            (self.api.get_energy_count)(
+                self.handle,
+                &mut energy_accumulator,
+                &mut counter_resolution,
+                &mut timestamp,
+            )
+        })?;
+        Ok((energy_accumulator as f64 * counter_resolution as f64 / 1000.0) as u64)
     }
 
     fn clock_bounds(&self, clock_type: u32) -> Option<(u32, u32)> {
@@ -744,6 +780,106 @@ impl AmdsmiGpu {
     }
 }
 
+pub(crate) fn validate_energy_counters(gpus: &mut [AmdsmiGpu]) -> Result<Vec<bool>, ZeusdError> {
+    if gpus.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    tracing::info!("Starting AMD energy counter validation; this takes 0.5 seconds");
+    for gpu in gpus.iter_mut() {
+        gpu.cumulative_energy_available = false;
+    }
+
+    let powers_mw = gpus
+        .iter_mut()
+        .map(|gpu| match gpu.get_instant_power_mw() {
+            Ok(power_mw) => Ok(power_mw),
+            Err(ZeusdError::AmdSmiError {
+                status: ffi::AMDSMI_STATUS_NOT_SUPPORTED,
+                ..
+            }) => Ok(0),
+            Err(error) => Err(error),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut initial_energies = Vec::with_capacity(gpus.len());
+    for (index, gpu) in gpus.iter().enumerate() {
+        match gpu.raw_total_energy_consumption() {
+            Ok(energy_mj) => initial_energies.push(Some(energy_mj)),
+            Err(ZeusdError::AmdSmiError {
+                status: ffi::AMDSMI_STATUS_NOT_SUPPORTED,
+                ..
+            }) => {
+                tracing::info!("GPU {} cumulative energy counter is not supported", index);
+                initial_energies.push(None);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    std::thread::sleep(Duration::from_millis(500));
+
+    let mut final_energies = Vec::with_capacity(gpus.len());
+    for (index, (gpu, initial_energy)) in gpus.iter().zip(&initial_energies).enumerate() {
+        if initial_energy.is_none() {
+            final_energies.push(None);
+            continue;
+        }
+        match gpu.raw_total_energy_consumption() {
+            Ok(energy_mj) => final_energies.push(Some(energy_mj)),
+            Err(ZeusdError::AmdSmiError {
+                status: ffi::AMDSMI_STATUS_NOT_SUPPORTED,
+                ..
+            }) => {
+                tracing::info!("GPU {} cumulative energy counter is not supported", index);
+                final_energies.push(None);
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    let mut flags = Vec::with_capacity(gpus.len());
+    for (index, gpu) in gpus.iter_mut().enumerate() {
+        let Some((initial_mj, final_mj)) = initial_energies[index].zip(final_energies[index])
+        else {
+            flags.push(false);
+            continue;
+        };
+        let expected_mj = powers_mw[index] as f64 * 0.5;
+        let measured_mj = final_mj as f64 - initial_mj as f64;
+        let available = match energy_counter_verdict(expected_mj, measured_mj) {
+            EnergyCounterVerdict::Reliable => {
+                tracing::info!(
+                    "GPU {} cumulative energy counter passed validation: expected {:.3} mJ, measured {:.3} mJ",
+                    index,
+                    expected_mj,
+                    measured_mj
+                );
+                true
+            }
+            EnergyCounterVerdict::CannotValidate => {
+                tracing::info!(
+                    "GPU {} power reading is zero or unsupported, so the cumulative energy counter cannot be validated; energy is disabled for this GPU; clients can poll power and integrate instead",
+                    index
+                );
+                false
+            }
+            EnergyCounterVerdict::Unreliable => {
+                tracing::info!(
+                    "GPU {} cumulative energy counter failed validation: expected {:.3} mJ, measured {:.3} mJ; see https://github.com/ROCm/amdsmi/issues/38; clients can poll power and integrate instead",
+                    index,
+                    expected_mj,
+                    measured_mj
+                );
+                false
+            }
+        };
+        gpu.cumulative_energy_available = available;
+        flags.push(available);
+    }
+    Ok(flags)
+}
+
 impl GpuManager for AmdsmiGpu {
     fn device_count() -> Result<u32, ZeusdError> {
         let api = amdsmi_api()?;
@@ -840,19 +976,16 @@ impl GpuManager for AmdsmiGpu {
     }
 
     fn get_total_energy_consumption(&mut self) -> Result<u64, ZeusdError> {
-        let mut energy_accumulator = 0;
-        let mut counter_resolution = 0.0;
-        let mut timestamp = 0;
-        // SAFETY: All output pointers refer to writable values of the expected types.
-        check_status(self.api, unsafe {
-            (self.api.get_energy_count)(
-                self.handle,
-                &mut energy_accumulator,
-                &mut counter_resolution,
-                &mut timestamp,
-            )
-        })?;
-        Ok((energy_accumulator as f64 * counter_resolution as f64 / 1000.0) as u64)
+        if !self.cumulative_energy_available {
+            return Err(ZeusdError::InvalidRequest(
+                "The cumulative energy counter of this GPU is not available. It is either \
+                 unsupported or failed validation at zeusd startup \
+                 (see https://github.com/ROCm/amdsmi/issues/38). Poll /gpu/get_power and \
+                 integrate over time instead."
+                    .into(),
+            ));
+        }
+        self.raw_total_energy_consumption()
     }
 }
 
@@ -1041,5 +1174,31 @@ mod tests {
             clk_write_order(Some((1_000, 1_500)), 1_500, 1_800),
             WriteOrder::MinFirst
         );
+    }
+
+    #[test]
+    fn energy_counter_cannot_be_validated_below_expected_threshold() {
+        assert_eq!(
+            energy_counter_verdict(0.0009, 0.0009),
+            EnergyCounterVerdict::CannotValidate
+        );
+    }
+
+    #[test]
+    fn energy_counter_is_reliable_inside_ratio_bounds() {
+        assert_eq!(
+            energy_counter_verdict(100.0, 100.0),
+            EnergyCounterVerdict::Reliable
+        );
+    }
+
+    #[test]
+    fn energy_counter_is_unreliable_at_or_beyond_ratio_bounds() {
+        for measured_mj in [9.0, 10.0, 1_000.0, 1_001.0] {
+            assert_eq!(
+                energy_counter_verdict(100.0, measured_mj),
+                EnergyCounterVerdict::Unreliable
+            );
+        }
     }
 }

--- a/zeusd/src/devices/gpu/nvml.rs
+++ b/zeusd/src/devices/gpu/nvml.rs
@@ -48,6 +48,32 @@ impl NvmlGpu<'static> {
     pub fn name(&self) -> Result<String, ZeusdError> {
         Ok(self.device.name()?)
     }
+
+    /// Read the GPU PCI address in domain:bus:device.function form.
+    pub fn pci_address(&self) -> Result<String, ZeusdError> {
+        let pci_info = self.device.pci_info()?;
+        Ok(format!(
+            "{:04x}:{:02x}:{:02x}.0",
+            pci_info.domain, pci_info.bus, pci_info.device
+        ))
+    }
+
+    pub(crate) fn validate_energy_counters(gpus: &mut [Self]) -> Result<Vec<bool>, ZeusdError> {
+        gpus.iter()
+            .enumerate()
+            .map(|(index, gpu)| match gpu.device.total_energy_consumption() {
+                Ok(_) => Ok(true),
+                Err(NvmlError::NotSupported) => {
+                    tracing::info!(
+                        "GPU {} driver does not support the total energy counter (pre-Volta GPU)",
+                        index
+                    );
+                    Ok(false)
+                }
+                Err(error) => Err(error.into()),
+            })
+            .collect()
+    }
 }
 
 impl GpuManager for NvmlGpu<'static> {

--- a/zeusd/src/routes/server.rs
+++ b/zeusd/src/routes/server.rs
@@ -13,6 +13,10 @@ use crate::config::ApiGroup;
 pub struct GpuDiscoveryInfo {
     pub id: usize,
     pub name: String,
+    /// PCI address in domain:bus:device.function form.
+    pub pci_address: String,
+    /// Whether the GPU provides a trustworthy cumulative energy counter.
+    pub cumulative_energy_available: bool,
 }
 
 /// CPU package information returned by `GET /discover`.

--- a/zeusd/src/startup.rs
+++ b/zeusd/src/startup.rs
@@ -91,6 +91,8 @@ pub fn get_unix_listener(
 trait StartupGpu: GpuManager + Send + Sized + 'static {
     fn init(index: u32) -> Result<Self, crate::error::ZeusdError>;
     fn name(&self) -> Result<String, crate::error::ZeusdError>;
+    fn pci_address(&self) -> Result<String, crate::error::ZeusdError>;
+    fn validate_energy_counters(gpus: &mut [Self]) -> Result<Vec<bool>, crate::error::ZeusdError>;
 }
 
 #[cfg(feature = "nvml")]
@@ -102,6 +104,14 @@ impl StartupGpu for NvmlGpu<'static> {
     fn name(&self) -> Result<String, crate::error::ZeusdError> {
         NvmlGpu::name(self)
     }
+
+    fn pci_address(&self) -> Result<String, crate::error::ZeusdError> {
+        NvmlGpu::pci_address(self)
+    }
+
+    fn validate_energy_counters(gpus: &mut [Self]) -> Result<Vec<bool>, crate::error::ZeusdError> {
+        NvmlGpu::validate_energy_counters(gpus)
+    }
 }
 
 #[cfg(feature = "amdsmi")]
@@ -112,6 +122,14 @@ impl StartupGpu for AmdsmiGpu {
 
     fn name(&self) -> Result<String, crate::error::ZeusdError> {
         AmdsmiGpu::name(self)
+    }
+
+    fn pci_address(&self) -> Result<String, crate::error::ZeusdError> {
+        Ok(AmdsmiGpu::bdf(self)?.to_string())
+    }
+
+    fn validate_energy_counters(gpus: &mut [Self]) -> Result<Vec<bool>, crate::error::ZeusdError> {
+        crate::devices::gpu::amdsmi::validate_energy_counters(gpus)
     }
 }
 
@@ -215,13 +233,25 @@ fn start_gpu_device_tasks_for<T: StartupGpu>(
     for gpu_id in 0..num_gpus {
         let gpu = T::init(gpu_id)?;
         let name = gpu.name()?;
+        let pci_address = gpu.pci_address()?;
         tracing::info!("Initialized {} for GPU {} ({})", backend_name, gpu_id, name);
-        gpu_info.push(GpuDiscoveryInfo {
-            id: gpu_id as usize,
-            name,
-        });
+        gpu_info.push((name, pci_address));
         gpus.push(gpu);
     }
+    let energy_flags = T::validate_energy_counters(&mut gpus)?;
+    let gpu_info = gpu_info
+        .into_iter()
+        .zip(energy_flags)
+        .enumerate()
+        .map(
+            |(id, ((name, pci_address), cumulative_energy_available))| GpuDiscoveryInfo {
+                id,
+                name,
+                pci_address,
+                cumulative_energy_available,
+            },
+        )
+        .collect();
     Ok((GpuManagementTasks::start(gpus)?, gpu_info))
 }
 

--- a/zeusd/tests/gpu.rs
+++ b/zeusd/tests/gpu.rs
@@ -1102,6 +1102,8 @@ async fn test_discover_endpoint() {
     assert_eq!(gpus.len(), NUM_GPUS as usize);
     assert_eq!(gpus[0]["id"].as_u64().unwrap(), 0);
     assert_eq!(gpus[0]["name"].as_str().unwrap(), "Test GPU 0");
+    assert_eq!(gpus[0]["pci_address"].as_str().unwrap(), "0000:00:00.0");
+    assert!(gpus[0]["cumulative_energy_available"].as_bool().unwrap());
     assert!(gpus[0].get("vendor").is_none());
     let cpus = body["cpus"].as_array().expect("cpus should be array");
     assert_eq!(cpus.len(), 1);

--- a/zeusd/tests/helpers/mod.rs
+++ b/zeusd/tests/helpers/mod.rs
@@ -3,6 +3,8 @@
 //! It has to be under `tests/helpers/mod.rs` instead of `tests/helpers.rs`
 //! to avoid it from being treated as another test module.
 
+#![allow(dead_code)]
+
 use once_cell::sync::Lazy;
 use paste::paste;
 use std::collections::HashSet;
@@ -476,6 +478,8 @@ impl TestApp {
                 .map(|id| GpuDiscoveryInfo {
                     id,
                     name: format!("Test GPU {id}"),
+                    pci_address: format!("0000:{:02x}:00.0", id),
+                    cumulative_energy_available: true,
                 })
                 .collect(),
             cpus: (0..cpu_count)
@@ -506,7 +510,7 @@ impl TestApp {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind TCP listener");
         let port = listener.local_addr().unwrap().port();
         let server = start_server_tcp(listener, state, 2).expect("Failed to start server");
-        let _ = tokio::spawn(server);
+        drop(tokio::spawn(server));
 
         TestApp {
             port,
@@ -588,6 +592,8 @@ impl TestApp {
                 .map(|id| GpuDiscoveryInfo {
                     id,
                     name: format!("Test GPU {id}"),
+                    pci_address: format!("0000:{:02x}:00.0", id),
+                    cumulative_energy_available: true,
                 })
                 .collect(),
             cpus: (0..cpu_count)
@@ -618,7 +624,7 @@ impl TestApp {
         let listener = TcpListener::bind("127.0.0.1:0").expect("Failed to bind TCP listener");
         let port = listener.local_addr().unwrap().port();
         let server = start_server_tcp(listener, state, 2).expect("Failed to start server");
-        let _ = tokio::spawn(server);
+        drop(tokio::spawn(server));
 
         TestApp {
             port,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU discovery now reports each device’s PCI address.
  * GPU records indicate whether cumulative energy measurements are available.
  * Energy-counter support is validated during startup for NVIDIA and AMD GPUs.

* **Bug Fixes**
  * Unreliable or unsupported energy counters are identified and safely rejected instead of returning invalid readings.

* **Documentation**
  * Added AMD GPU setup, virtualization, energy monitoring, ROCm, and troubleshooting guidance.
  * Documented systemd requirements and AMD-specific service configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->