### PR TITLE
Fix AMD GPU clock resets in `AMDGPU`

### DIFF
--- a/tests/device/gpu/test_amd.py
+++ b/tests/device/gpu/test_amd.py
@@ -220,6 +220,22 @@ def test_zeusd_gpu_skips_unchanged_power_limit(fresh_amd_module):
     client.set_power_limit.assert_not_called()
 
 
+def test_local_gpu_rejects_single_domain_clock_resets(fresh_amd_module):
+    """Reject AMD single-domain reset requests without amdsmi calls."""
+    amdsmi_mock = _make_amdsmi_mock({"h0": 0})
+    amd = fresh_amd_module(amdsmi_mock)
+    gpu = amd.AMDGPU(0)
+
+    import zeus.device.gpu.common as gpu_common
+
+    with pytest.raises(gpu_common.ZeusGPUNotSupportedError, match="cannot reset a single clock domain"):
+        gpu.reset_gpu_locked_clocks(block=False)
+    with pytest.raises(gpu_common.ZeusGPUNotSupportedError, match="cannot reset a single clock domain"):
+        gpu.reset_memory_locked_clocks(block=False)
+
+    amdsmi_mock.amdsmi_set_gpu_clk_range.assert_not_called()
+
+
 def test_zeusd_gpu_rejects_single_domain_clock_resets(fresh_amd_module):
     """Reject AMD single-domain reset requests without daemon calls."""
     amdsmi_mock = _make_amdsmi_mock({"h0": 0})

--- a/zeus/device/gpu/amd.py
+++ b/zeus/device/gpu/amd.py
@@ -266,19 +266,11 @@ class AMDGPU(gpu_common.GPU):
             clk_type=amdsmi.AmdSmiClkType.MEM,
         )
 
-    @_handle_amdsmi_errors
     def reset_memory_locked_clocks(self, block: bool = True) -> None:
-        """Reset the locked memory clocks to the default."""
-        # Get default MEM clock values
-        info = amdsmi.amdsmi_get_clock_info(self.handle, amdsmi.AmdSmiClkType.MEM)  # returns MHz
-
-        self._warn_sys_admin()
-        amdsmi.amdsmi_set_gpu_clk_range(
-            self.handle,
-            info["min_clk"],
-            info["max_clk"],
-            clk_type=amdsmi.AmdSmiClkType.MEM,
-        )  # expects MHz
+        """Raise because AMD GPUs cannot reset only the memory clock domain."""
+        raise gpu_common.ZeusGPUNotSupportedError(
+            "AMD GPUs cannot reset a single clock domain. Use `reset_locked_clocks` to reset all clock domains."
+        )
 
     @_handle_amdsmi_errors
     def get_supported_graphics_clocks(self, memory_clock_mhz: int | None = None) -> list[int]:
@@ -303,19 +295,21 @@ class AMDGPU(gpu_common.GPU):
             clk_type=amdsmi.AmdSmiClkType.GFX,
         )
 
-    @_handle_amdsmi_errors
     def reset_gpu_locked_clocks(self, block: bool = True) -> None:
-        """Reset the locked GPU clocks to the default."""
-        # Get default GPU clock values
-        info = amdsmi.amdsmi_get_clock_info(self.handle, amdsmi.AmdSmiClkType.GFX)  # returns MHz
+        """Raise because AMD GPUs cannot reset only the GPU clock domain."""
+        raise gpu_common.ZeusGPUNotSupportedError(
+            "AMD GPUs cannot reset a single clock domain. Use `reset_locked_clocks` to reset all clock domains."
+        )
 
+    @_handle_amdsmi_errors
+    def reset_locked_clocks(self, block: bool = True) -> None:
+        """Reset all clock domains to their defaults.
+
+        AMD GPUs offer no per-domain clock reset. Setting the performance level
+        back to automatic restores default frequency management for all domains.
+        """
         self._warn_sys_admin()
-        amdsmi.amdsmi_set_gpu_clk_range(
-            self.handle,
-            info["min_clk"],
-            info["max_clk"],
-            clk_type=amdsmi.AmdSmiClkType.GFX,
-        )  # expects MHz
+        amdsmi.amdsmi_set_gpu_perf_level(self.handle, amdsmi.AmdSmiDevPerfLevel.AUTO)
 
     def _ensure_not_dual_die_odd_chiplet(self) -> None:
         """Raise an error if the GPU is a chiplet of a dual-die AMD Instinct MI250/MI250X GPU."""
@@ -495,12 +489,6 @@ class ZeusdAMDGPU(AMDGPU):
             block,
         )
 
-    def reset_memory_locked_clocks(self, block: bool = True) -> None:
-        """Raise because AMD GPUs cannot reset only the memory clock domain."""
-        raise gpu_common.ZeusGPUNotSupportedError(
-            "AMD GPUs cannot reset a single clock domain. Use `reset_locked_clocks` to reset all clock domains."
-        )
-
     def set_gpu_locked_clocks(self, min_clock_mhz: int, max_clock_mhz: int, block: bool = True) -> None:
         """Lock the GPU clock to a specified range. Units: MHz."""
         self._client.set_gpu_locked_clocks(
@@ -508,12 +496,6 @@ class ZeusdAMDGPU(AMDGPU):
             min_clock_mhz,
             max_clock_mhz,
             block,
-        )
-
-    def reset_gpu_locked_clocks(self, block: bool = True) -> None:
-        """Raise because AMD GPUs cannot reset only the GPU clock domain."""
-        raise gpu_common.ZeusGPUNotSupportedError(
-            "AMD GPUs cannot reset a single clock domain. Use `reset_locked_clocks` to reset all clock domains."
         )
 
     def reset_locked_clocks(self, block: bool = True) -> None:

--- a/zeus/optimizer/pipeline_frequency/frequency_controller.py
+++ b/zeus/optimizer/pipeline_frequency/frequency_controller.py
@@ -64,5 +64,4 @@ class FrequencyController:
 
         # Reset everything.
         with contextlib.suppress(ZeusGPUNotSupportedError):
-            gpus.reset_memory_locked_clocks(device_id)
-        gpus.reset_gpu_locked_clocks(device_id)
+            gpus.reset_locked_clocks(device_id)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resetting all AMD GPU clock domains together.
  * Full clock resets now restore automatic performance management.

* **Bug Fixes**
  * Prevented unsupported single-domain GPU or memory clock reset requests from calling the AMD management interface.
  * Updated cleanup to consistently perform a complete clock reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->