### PR TITLE
[Zeusd] GPU command override 

### DIFF
--- a/docs/zeusd/api.md
+++ b/docs/zeusd/api.md
@@ -2,7 +2,7 @@
 
 The API is the same regardless of transport. Paths shown below are server-relative; prefix with `http://<host>:<port>` over TCP, the UDS socket over UDS, or the named pipe on Windows.
 
-Status codes: `200` success; `400` bad input or unsupported op (e.g., persistence-mode off on Windows); `401` missing/invalid token; `403` insufficient token scope or NVML `NoPermission`; `404` disabled API group or `/auth/*` on a no-auth daemon. Per-device write calls aggregate per-device errors into `{"errors": {"<device_id>": "<message>"}}` with the worst per-device status.
+Status codes: `200` success; `400` bad input or unsupported op (e.g., persistence-mode off on Windows); `401` missing/invalid token; `403` insufficient token scope or NVML `NoPermission`; `404` disabled API group or `/auth/*` on a no-auth daemon; `500` daemon-side failure, e.g., an unexpected driver error or a failed [override command](command_overrides.md). Per-device write calls aggregate per-device errors into `{"errors": {"<device_id>": "<message>"}}` with the worst per-device status.
 
 ## `GET /discover`
 

--- a/docs/zeusd/api.md
+++ b/docs/zeusd/api.md
@@ -1,0 +1,134 @@
+# HTTP API Reference
+
+The API is the same regardless of transport. Paths shown below are server-relative; prefix with `http://<host>:<port>` over TCP, the UDS socket over UDS, or the named pipe on Windows.
+
+Status codes: `200` success; `400` bad input or unsupported op (e.g., persistence-mode off on Windows); `401` missing/invalid token; `403` insufficient token scope or NVML `NoPermission`; `404` disabled API group or `/auth/*` on a no-auth daemon. Per-device write calls aggregate per-device errors into `{"errors": {"<device_id>": "<message>"}}` with the worst per-device status.
+
+## `GET /discover`
+
+Available devices, capabilities, and enabled API groups. Always available; never requires auth.
+
+```json
+{
+  "gpus": [
+    {"id": 0, "name": "NVIDIA A40", "pci_address": "0000:01:00.0", "cumulative_energy_available": true},
+    {"id": 1, "name": "NVIDIA A40", "pci_address": "0000:41:00.0", "cumulative_energy_available": true}
+  ],
+  "cpus": [
+    {"id": 0, "dram_available": true},
+    {"id": 1, "dram_available": false}
+  ],
+  "enabled_api_groups": ["gpu-control", "gpu-read", "cpu-read"],
+  "auth_required": false
+}
+```
+
+`pci_address` is the PCI domain:bus:device.function address, formatted as in `lspci -D`.
+`cumulative_energy_available` states whether the GPU has a trustworthy cumulative energy counter; when false, `GET /gpu/get_cumulative_energy` returns 400 for that GPU (see [Notes on Platforms](index.md#notes-on-platforms)).
+
+## `GET /time`
+
+Daemon-side Unix timestamp in milliseconds. Always available.
+
+```json
+{"timestamp_ms": 1762000000000}
+```
+
+## `GET /auth/whoami`
+
+Authenticated user's identity and scopes. Requires a bearer token. Returns 404 when auth is disabled.
+
+```json
+{"sub": "alice", "scopes": ["gpu-read", "gpu-control"], "exp": 1762864200}
+```
+
+`exp` is omitted for tokens issued with `--expires never`.
+
+## GPU
+
+All endpoints are under `/gpu`. `gpu_ids` is a comma-separated list of GPU indices: required on writes; optional on reads (omit to apply to / read all GPUs).
+
+Writes (`POST`) also take `block` (bool): `true` waits for completion and reports per-GPU execution errors; `false` dispatches non-blocking and only reports MPSC send errors.
+
+| Method | Path | Extra params / notes |
+|---|---|---|
+| `POST` | `/gpu/set_power_limit` | `power_limit_mw` |
+| `POST` | `/gpu/set_persistence_mode` | `enabled`; AMD GPUs return 400 because persistence mode is an NVML concept (see [Windows notes](index.md#windows)). |
+| `POST` | `/gpu/set_gpu_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
+| `POST` | `/gpu/reset_gpu_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
+| `POST` | `/gpu/set_mem_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
+| `POST` | `/gpu/reset_mem_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
+| `POST` | `/gpu/reset_locked_clocks` | resets all clock domains |
+| `GET`  | `/gpu/get_cumulative_energy` | GPUs whose `cumulative_energy_available` is false in `/discover` return 400. |
+| `GET`  | `/gpu/get_power` | one-shot snapshot |
+| `GET`  | `/gpu/stream_power` | SSE stream |
+| `GET`  | `/gpu/get_power_limit` | -- |
+| `GET`  | `/gpu/get_power_limit_constraints` | -- |
+| `GET`  | `/gpu/get_persistence_mode` | AMD GPUs return 400 because persistence mode is an NVML concept; always `true` on Windows. |
+
+`get_cumulative_energy` response (keyed by GPU index as string):
+
+```json
+{"0": {"energy_mj": 123456}, "1": {"energy_mj": 789012}}
+```
+
+`get_power` returns a snapshot keyed by GPU index:
+
+```json
+{"timestamp_ms": 1762000000000, "power_mw": {"0": 75000, "1": 120000}}
+```
+
+`stream_power` emits one SSE event per GPU sample:
+
+```text
+data: {"timestamp_ms": 1762000000000, "gpu_id": 0, "power_mw": 75000}
+```
+
+If `gpu_ids` is provided, only those GPUs are polled.
+
+`get_power_limit`, `get_power_limit_constraints`, and `get_persistence_mode` responses (keyed by GPU index as string):
+
+```json
+{"0": {"power_limit_mw": 200000}, "1": {"power_limit_mw": 250000}}
+{"0": {"min_power_limit_mw": 100000, "max_power_limit_mw": 300000}}
+{"0": {"enabled": true}, "1": {"enabled": false}}
+```
+
+## CPU
+
+All endpoints are under `/cpu` (Linux only). `cpu_ids` is a comma-separated list of RAPL package indices (the `N` in `/sys/class/powercap/intel-rapl/intel-rapl:N/`, not core or hyperthread IDs); optional on all endpoints (omit to read all CPUs).
+
+| Method | Path | Extra params / notes |
+|---|---|---|
+| `GET` | `/cpu/get_cumulative_energy` | `cpu` (bool) and `dram` (bool), both required |
+| `GET` | `/cpu/get_power` | one-shot snapshot |
+| `GET` | `/cpu/stream_power` | SSE stream |
+
+`get_cumulative_energy` response (fields nullable):
+
+```json
+{
+  "0": {"cpu_energy_uj": 123456, "dram_energy_uj": 78901},
+  "1": {"cpu_energy_uj": 234567, "dram_energy_uj": null}
+}
+```
+
+`get_power` returns a snapshot keyed by CPU index:
+
+```json
+{
+  "timestamp_ms": 1762000000000,
+  "power_mw": {
+    "0": {"cpu_mw": 85000, "dram_mw": 12000},
+    "1": {"cpu_mw": 78000, "dram_mw": null}
+  }
+}
+```
+
+`stream_power` emits one SSE event per CPU package sample:
+
+```text
+data: {"timestamp_ms": 1762000000000, "cpu_id": 0, "cpu_mw": 85000, "dram_mw": 12000}
+```
+
+If `cpu_ids` is provided, only those CPU packages are polled.

--- a/docs/zeusd/command_overrides.md
+++ b/docs/zeusd/command_overrides.md
@@ -1,0 +1,52 @@
+# GPU Command Overrides
+
+Some machines never grant root.
+On shared HPC clusters, for example, the closest thing to privileged GPU control is often a set of admin-blessed commands, such as sudoers-whitelisted scripts wrapping the vendor CLI.
+The native `gpu-control` path cannot run there, because setting power limits and clock ranges through NVML or AMD SMI requires root.
+
+`zeusd serve --gpu-command-overrides PATH` closes this gap by replacing selected privileged GPU writes with commands from a TOML file.
+The daemon runs unprivileged, the configured commands carry the privilege, and clients keep using the same HTTP API and Zeus Python integrations unchanged.
+
+```toml
+[set_power_limit]
+commands = ["sudo /usr/local/bin/set_powercap.sh -value {power_limit_w} -gpu {gpu_id}"]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+
+[set_gpu_locked_clocks]
+commands = [
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value 500 -gpu {gpu_id}",
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit max -value {max_clock_mhz} -gpu {gpu_id}",
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value {min_clock_mhz} -gpu {gpu_id}",
+]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+
+[reset_locked_clocks]
+commands = ["sudo /usr/local/bin/reset_gpu_clocks.sh"]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+```
+
+Any subset of the seven operations may be configured.
+Each operation requires a nonempty `commands` array and accepts an optional `timeout_s`, which defaults to 60 seconds and applies to each command in the array separately.
+
+| Operations | Valid placeholders |
+|---|---|
+| All operations | `{gpu_id}` |
+| `set_power_limit` | `{power_limit_mw}`, `{power_limit_w}` |
+| `set_gpu_locked_clocks`, `set_mem_locked_clocks` | `{min_clock_mhz}`, `{max_clock_mhz}` |
+| `set_persistence_mode` | `{enabled}` (`1` or `0`) |
+| `reset_gpu_locked_clocks`, `reset_mem_locked_clocks`, `reset_locked_clocks` | Only `{gpu_id}` |
+
+Commands are word-split and executed directly, without a shell.
+Use a wrapper script when pipes, redirection, or other shell behavior is needed.
+Commands run as the zeusd user, so the command must perform any required privilege escalation, such as passwordless `sudo`; no TTY is available.
+
+An `error_pattern` is matched against combined stdout and stderr, and a match fails the operation even after a zero exit status; `amd-smi`, for example, can exit zero when the kernel rejects a write.
+Commands run sequentially and stop at the first failure; commands that already ran are not rolled back.
+
+A command without `{gpu_id}` affects whatever scope the command implements; the reset script above resets every GPU in the node.
+For CLIs that set one clock bound per call, a plain min-then-max pair fails whenever the new minimum is above the currently applied maximum; the example's three-command sequence (minimum to the hardware floor, then maximum, then minimum) works from any starting range.
+
+When at least one override is configured, `gpu-control` no longer requires zeusd itself to run as root.
+Without root, control operations that lack an override use the native driver path and will fail with driver permission errors.
+
+Because the file decides which commands zeusd executes, zeusd refuses to start on Unix if it is world-writable or owned by neither root nor the user running zeusd; keep its containing directory equally protected.

--- a/docs/zeusd/command_overrides.md
+++ b/docs/zeusd/command_overrides.md
@@ -4,7 +4,8 @@ Some machines never grant root.
 On shared HPC clusters, for example, the closest thing to privileged GPU control is often a set of admin-blessed commands, such as sudoers-whitelisted scripts wrapping the vendor CLI.
 The native `gpu-control` path cannot run there, because setting power limits and clock ranges through NVML or AMD SMI requires root.
 
-`zeusd serve --gpu-command-overrides PATH` closes this gap by replacing selected privileged GPU writes with commands from a TOML file.
+`zeusd serve --enable gpu-read,gpu-control --gpu-command-overrides PATH` closes this gap by replacing selected privileged GPU writes with commands from a TOML file.
+Note the explicit `--enable`: the default list also contains `cpu-read`, which requires root regardless of overrides.
 The daemon runs unprivileged, the configured commands carry the privilege, and clients keep using the same HTTP API and Zeus Python integrations unchanged.
 
 ```toml

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -115,13 +115,64 @@ Selectively enable with `--enable`:
 
 | Group | What | Needs root |
 |---|---|:---:|
-| `gpu-control` | `POST /gpu/{set,reset}_*` (power limit, locked clocks, persistence) | Yes |
+| `gpu-control` | `POST /gpu/{set,reset}_*` (power limit, locked clocks, persistence) | Unless command overrides are configured |
 | `gpu-read` | `GET /gpu/{get,stream}_power`, `get_cumulative_energy` | No |
 | `cpu-read` (Linux) | `GET /cpu/{get,stream}_power`, `get_cumulative_energy` | Yes |
 
 `/discover`, `/time`, and `/auth/whoami` are always available. On Linux, the daemon refuses to start if a root-required group is enabled without root; on Windows there's no admin check, and unprivileged NVML writes surface as HTTP 403.
 
 For read-only monitoring without root: `--enable gpu-read`.
+
+### GPU command overrides
+
+`--gpu-command-overrides PATH` replaces selected privileged GPU writes with commands from a TOML file.
+This lets `gpu-control` run without root when privilege is available only through commands such as passwordless sudoers scripts.
+
+```toml
+[set_power_limit]
+commands = ["sudo /usr/local/bin/set_powercap.sh -value {power_limit_w} -gpu {gpu_id}"]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+
+[set_gpu_locked_clocks]
+commands = [
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value 500 -gpu {gpu_id}",
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit max -value {max_clock_mhz} -gpu {gpu_id}",
+  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value {min_clock_mhz} -gpu {gpu_id}",
+]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+
+[reset_locked_clocks]
+commands = ["sudo /usr/local/bin/reset_gpu_clocks.sh"]
+error_pattern = "(?i)error|fail|cannot|unable|not supported"
+```
+
+Any subset of the seven operations may be configured.
+Each operation requires a nonempty `commands` array and accepts an optional `timeout_s` per command, which defaults to 60 seconds.
+
+| Operations | Valid placeholders |
+|---|---|
+| All operations | `{gpu_id}` |
+| `set_power_limit` | `{power_limit_mw}`, `{power_limit_w}` |
+| `set_gpu_locked_clocks`, `set_mem_locked_clocks` | `{min_clock_mhz}`, `{max_clock_mhz}` |
+| `set_persistence_mode` | `{enabled}` (`1` or `0`) |
+| `reset_gpu_locked_clocks`, `reset_mem_locked_clocks`, `reset_locked_clocks` | Only `{gpu_id}` |
+
+Commands are word-split and executed directly, without a shell.
+Use a wrapper script when pipes, redirection, or other shell behavior is needed.
+Commands run as the zeusd user, so the command must perform any required privilege escalation, such as passwordless `sudo`; no TTY is available.
+
+An `error_pattern` is matched against combined stdout and stderr, and a match fails the operation even after a zero exit status.
+This is useful for tools such as `amd-smi`, which can exit zero when the kernel rejects a write.
+Commands run sequentially and stop at the first failure.
+There is no rollback: the effects of commands that already ran persist.
+
+A command without `{gpu_id}` affects whatever scope the command implements.
+For example, the reset script above resets every GPU in the node.
+For CLIs that set one clock bound per call, the three-command sequence above first lowers the minimum to the hardware floor, then sets the maximum and target minimum.
+This widen-then-narrow order handles valid target ranges whose new minimum is above the current maximum.
+
+When at least one override is configured, `gpu-control` no longer requires zeusd itself to run as root.
+Without root, control operations that lack an override use the native driver path and will fail with driver permission errors.
 
 ## Python integration
 

--- a/docs/zeusd/index.md
+++ b/docs/zeusd/index.md
@@ -107,72 +107,20 @@ cargo install zeusd --no-default-features --features amdsmi
 
 Defaults to all API groups on Linux, GPU only on Windows.
 
-The daemon searches for `libamd_smi.so` once at startup: `/opt/rocm/lib`, then the newest `/opt/rocm-*/lib`, then the dynamic loader paths. Setting `AMDSMI_LIB_DIR` (a library directory) or `ROCM_PATH` (a ROCm installation root) restricts the search to that installation, e.g. `ROCM_PATH=/opt/rocm-7.2.0 zeusd serve`.
-
 ## API groups
 
 Selectively enable with `--enable`:
 
 | Group | What | Needs root |
 |---|---|:---:|
-| `gpu-control` | `POST /gpu/{set,reset}_*` (power limit, locked clocks, persistence) | Unless command overrides are configured |
+| `gpu-control` | `POST /gpu/{set,reset}_*` (power limit, locked clocks, persistence) | Yes |
 | `gpu-read` | `GET /gpu/{get,stream}_power`, `get_cumulative_energy` | No |
 | `cpu-read` (Linux) | `GET /cpu/{get,stream}_power`, `get_cumulative_energy` | Yes |
 
 `/discover`, `/time`, and `/auth/whoami` are always available. On Linux, the daemon refuses to start if a root-required group is enabled without root; on Windows there's no admin check, and unprivileged NVML writes surface as HTTP 403.
 
 For read-only monitoring without root: `--enable gpu-read`.
-
-### GPU command overrides
-
-`--gpu-command-overrides PATH` replaces selected privileged GPU writes with commands from a TOML file.
-This lets `gpu-control` run without root when privilege is available only through commands such as passwordless sudoers scripts.
-
-```toml
-[set_power_limit]
-commands = ["sudo /usr/local/bin/set_powercap.sh -value {power_limit_w} -gpu {gpu_id}"]
-error_pattern = "(?i)error|fail|cannot|unable|not supported"
-
-[set_gpu_locked_clocks]
-commands = [
-  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value 500 -gpu {gpu_id}",
-  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit max -value {max_clock_mhz} -gpu {gpu_id}",
-  "sudo /usr/local/bin/set_gpu_clockfreq.sh -clock sclk -limit min -value {min_clock_mhz} -gpu {gpu_id}",
-]
-error_pattern = "(?i)error|fail|cannot|unable|not supported"
-
-[reset_locked_clocks]
-commands = ["sudo /usr/local/bin/reset_gpu_clocks.sh"]
-error_pattern = "(?i)error|fail|cannot|unable|not supported"
-```
-
-Any subset of the seven operations may be configured.
-Each operation requires a nonempty `commands` array and accepts an optional `timeout_s` per command, which defaults to 60 seconds.
-
-| Operations | Valid placeholders |
-|---|---|
-| All operations | `{gpu_id}` |
-| `set_power_limit` | `{power_limit_mw}`, `{power_limit_w}` |
-| `set_gpu_locked_clocks`, `set_mem_locked_clocks` | `{min_clock_mhz}`, `{max_clock_mhz}` |
-| `set_persistence_mode` | `{enabled}` (`1` or `0`) |
-| `reset_gpu_locked_clocks`, `reset_mem_locked_clocks`, `reset_locked_clocks` | Only `{gpu_id}` |
-
-Commands are word-split and executed directly, without a shell.
-Use a wrapper script when pipes, redirection, or other shell behavior is needed.
-Commands run as the zeusd user, so the command must perform any required privilege escalation, such as passwordless `sudo`; no TTY is available.
-
-An `error_pattern` is matched against combined stdout and stderr, and a match fails the operation even after a zero exit status.
-This is useful for tools such as `amd-smi`, which can exit zero when the kernel rejects a write.
-Commands run sequentially and stop at the first failure.
-There is no rollback: the effects of commands that already ran persist.
-
-A command without `{gpu_id}` affects whatever scope the command implements.
-For example, the reset script above resets every GPU in the node.
-For CLIs that set one clock bound per call, the three-command sequence above first lowers the minimum to the hardware floor, then sets the maximum and target minimum.
-This widen-then-narrow order handles valid target ranges whose new minimum is above the current maximum.
-
-When at least one override is configured, `gpu-control` no longer requires zeusd itself to run as root.
-Without root, control operations that lack an override use the native driver path and will fail with driver permission errors.
+When root is unavailable but privileged commands are (e.g., passwordless sudoers scripts), `gpu-control` can delegate writes to external commands; see [GPU Command Overrides](command_overrides.md).
 
 ## Python integration
 
@@ -185,7 +133,7 @@ export ZEUSD_HOST_PORT=node1:4938                # TCP
 
 When set, [`NVIDIAGPUs`][zeus.device.gpu.nvidia.NVIDIAGPUs], [`AMDGPUs`][zeus.device.gpu.amd.AMDGPUs], and [`RAPLCPUs`][zeus.device.cpu.rapl.RAPLCPUs] auto-switch to [`ZeusdNVIDIAGPU`][zeus.device.gpu.nvidia.ZeusdNVIDIAGPU] / [`ZeusdAMDGPU`][zeus.device.gpu.amd.ZeusdAMDGPU] / [`ZeusdRAPLCPU`][zeus.device.cpu.rapl.ZeusdRAPLCPU] backends; privileged GPU calls and CPU/DRAM reads are relayed through the daemon transparently.
 
-For lower-level access: [`ZeusdClient`][zeus.utils.zeusd.ZeusdClient] is a typed wrapper over every HTTP endpoint, and [`require_capabilities`][zeus.utils.zeusd.require_capabilities] fails fast if the daemon's capabilities don't match what your code needs.
+For lower-level access: [`ZeusdClient`][zeus.utils.zeusd.ZeusdClient] is a typed wrapper over every [HTTP endpoint](api.md), and [`require_capabilities`][zeus.utils.zeusd.require_capabilities] fails fast if the daemon's capabilities don't match what your code needs.
 
 For distributed power streaming across nodes, see [Distributed Power Measurement and Aggregation](../measure/index.md#distributed-power-measurement-and-aggregation).
 
@@ -239,9 +187,8 @@ Per AMD SMI's platform support, clock locking and the energy counter work only o
 Power capping additionally works on virtualization hosts and single-VF (SR-IOV) guests, but not on multi-VF or Windows guests.
 On virtualized AMD GPUs, these operations return 400.
 
-When ROCm is outside the default search locations, point the daemon at it in `/etc/default/zeusd`.
-`ROCM_PATH` is a ROCm installation root whose `lib/` contains `libamd_smi.so.<abi>`, e.g., `ROCM_PATH=/opt/rocm-7.2.0`.
-`AMDSMI_LIB_DIR` is any directory that directly contains `libamd_smi.so.<abi>`, e.g., `AMDSMI_LIB_DIR=/opt/rocm-7.2.0/lib`.
+The daemon searches for `libamd_smi.so` once at startup: `/opt/rocm/lib`, then the newest `/opt/rocm-*/lib`, then the dynamic loader paths.
+To pin a specific installation, set `ROCM_PATH` (a ROCm installation root, e.g., `/opt/rocm-7.2.0`) or `AMDSMI_LIB_DIR` (a directory directly containing `libamd_smi.so.<abi>`, e.g., `/opt/rocm-7.2.0/lib`); under systemd, in `/etc/default/zeusd`.
 
 ## Troubleshooting
 
@@ -251,138 +198,3 @@ When ROCm is outside the default search locations, point the daemon at it in `/e
 - **AMD GPUs not detected.** GPU backends are probed once at startup, so `zeusd` must start after the `amdgpu` driver is loaded (order the systemd unit accordingly, or restart the daemon).
 - **AMD SMI startup fails with `AMDSMI_STATUS_UNEXPECTED_DATA` (error 43).** The AMD SMI library is older than the GPU it is reading (e.g., ROCm 6.4 userspace on an MI300X). Point `ROCM_PATH` or `AMDSMI_LIB_DIR` at a ROCm release that supports the GPU.
 - **Logs.** `journalctl -u zeusd -f` under systemd; stderr otherwise.
-
-## HTTP API reference
-
-The API is the same regardless of transport. Paths shown below are server-relative; prefix with `http://<host>:<port>` over TCP, the UDS socket over UDS, or the named pipe on Windows.
-
-Status codes: `200` success; `400` bad input or unsupported op (e.g., persistence-mode off on Windows); `401` missing/invalid token; `403` insufficient token scope or NVML `NoPermission`; `404` disabled API group or `/auth/*` on a no-auth daemon. Per-device write calls aggregate per-device errors into `{"errors": {"<device_id>": "<message>"}}` with the worst per-device status.
-
-### `GET /discover`
-
-Available devices, capabilities, and enabled API groups. Always available; never requires auth.
-
-```json
-{
-  "gpus": [
-    {"id": 0, "name": "NVIDIA A40", "pci_address": "0000:01:00.0", "cumulative_energy_available": true},
-    {"id": 1, "name": "NVIDIA A40", "pci_address": "0000:41:00.0", "cumulative_energy_available": true}
-  ],
-  "cpus": [
-    {"id": 0, "dram_available": true},
-    {"id": 1, "dram_available": false}
-  ],
-  "enabled_api_groups": ["gpu-control", "gpu-read", "cpu-read"],
-  "auth_required": false
-}
-```
-
-`pci_address` is the PCI domain:bus:device.function address, formatted as in `lspci -D`.
-`cumulative_energy_available` states whether the GPU has a trustworthy cumulative energy counter; when false, `GET /gpu/get_cumulative_energy` returns 400 for that GPU (see [Notes on Platforms](#notes-on-platforms)).
-
-### `GET /time`
-
-Daemon-side Unix timestamp in milliseconds. Always available.
-
-```json
-{"timestamp_ms": 1762000000000}
-```
-
-### `GET /auth/whoami`
-
-Authenticated user's identity and scopes. Requires a bearer token. Returns 404 when auth is disabled.
-
-```json
-{"sub": "alice", "scopes": ["gpu-read", "gpu-control"], "exp": 1762864200}
-```
-
-`exp` is omitted for tokens issued with `--expires never`.
-
-### GPU
-
-All endpoints are under `/gpu`. `gpu_ids` is a comma-separated list of GPU indices: required on writes; optional on reads (omit to apply to / read all GPUs).
-
-Writes (`POST`) also take `block` (bool): `true` waits for completion and reports per-GPU execution errors; `false` dispatches non-blocking and only reports MPSC send errors.
-
-| Method | Path | Extra params / notes |
-|---|---|---|
-| `POST` | `/gpu/set_power_limit` | `power_limit_mw` |
-| `POST` | `/gpu/set_persistence_mode` | `enabled`; AMD GPUs return 400 because persistence mode is an NVML concept (see [Windows notes](#windows)). |
-| `POST` | `/gpu/set_gpu_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
-| `POST` | `/gpu/reset_gpu_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
-| `POST` | `/gpu/set_mem_locked_clocks` | `min_clock_mhz`, `max_clock_mhz` |
-| `POST` | `/gpu/reset_mem_locked_clocks` | On AMD GPUs, returns 400 (no per-domain reset exists); use `reset_locked_clocks`. |
-| `POST` | `/gpu/reset_locked_clocks` | resets all clock domains |
-| `GET`  | `/gpu/get_cumulative_energy` | GPUs whose `cumulative_energy_available` is false in `/discover` return 400. |
-| `GET`  | `/gpu/get_power` | one-shot snapshot |
-| `GET`  | `/gpu/stream_power` | SSE stream |
-| `GET`  | `/gpu/get_power_limit` | -- |
-| `GET`  | `/gpu/get_power_limit_constraints` | -- |
-| `GET`  | `/gpu/get_persistence_mode` | AMD GPUs return 400 because persistence mode is an NVML concept; always `true` on Windows. |
-
-`get_cumulative_energy` response (keyed by GPU index as string):
-
-```json
-{"0": {"energy_mj": 123456}, "1": {"energy_mj": 789012}}
-```
-
-`get_power` returns a snapshot keyed by GPU index:
-
-```json
-{"timestamp_ms": 1762000000000, "power_mw": {"0": 75000, "1": 120000}}
-```
-
-`stream_power` emits one SSE event per GPU sample:
-
-```text
-data: {"timestamp_ms": 1762000000000, "gpu_id": 0, "power_mw": 75000}
-```
-
-If `gpu_ids` is provided, only those GPUs are polled.
-
-`get_power_limit`, `get_power_limit_constraints`, and `get_persistence_mode` responses (keyed by GPU index as string):
-
-```json
-{"0": {"power_limit_mw": 200000}, "1": {"power_limit_mw": 250000}}
-{"0": {"min_power_limit_mw": 100000, "max_power_limit_mw": 300000}}
-{"0": {"enabled": true}, "1": {"enabled": false}}
-```
-
-### CPU
-
-All endpoints are under `/cpu` (Linux only). `cpu_ids` is a comma-separated list of RAPL package indices (the `N` in `/sys/class/powercap/intel-rapl/intel-rapl:N/`, not core or hyperthread IDs); optional on all endpoints (omit to read all CPUs).
-
-| Method | Path | Extra params / notes |
-|---|---|---|
-| `GET` | `/cpu/get_cumulative_energy` | `cpu` (bool) and `dram` (bool), both required |
-| `GET` | `/cpu/get_power` | one-shot snapshot |
-| `GET` | `/cpu/stream_power` | SSE stream |
-
-`get_cumulative_energy` response (fields nullable):
-
-```json
-{
-  "0": {"cpu_energy_uj": 123456, "dram_energy_uj": 78901},
-  "1": {"cpu_energy_uj": 234567, "dram_energy_uj": null}
-}
-```
-
-`get_power` returns a snapshot keyed by CPU index:
-
-```json
-{
-  "timestamp_ms": 1762000000000,
-  "power_mw": {
-    "0": {"cpu_mw": 85000, "dram_mw": 12000},
-    "1": {"cpu_mw": 78000, "dram_mw": null}
-  }
-}
-```
-
-`stream_power` emits one SSE event per CPU package sample:
-
-```text
-data: {"timestamp_ms": 1762000000000, "cpu_id": 0, "cpu_mw": 85000, "dram_mw": 12000}
-```
-
-If `cpu_ids` is provided, only those CPU packages are polled.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,7 +107,10 @@ nav:
   - Zeus: index.md
   - Getting Started: getting_started/index.md
   - Measuring Energy: measure/index.md
-  - Zeus Daemon: zeusd/index.md
+  - Zeus Daemon:
+    - zeusd/index.md
+    - GPU Command Overrides: zeusd/command_overrides.md
+    - HTTP API Reference: zeusd/api.md
   - Optimizing Energy:
     - optimize/index.md
     - Power Limit Optimizer: optimize/power_limit_optimizer.md

--- a/zeusd/Cargo.lock
+++ b/zeusd/Cargo.lock
@@ -1676,6 +1676,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,6 +1715,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -1965,6 +1980,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2382,6 +2438,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,13 +2581,16 @@ dependencies = [
  "nvml-wrapper",
  "once_cell",
  "paste",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "shell-words",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-actix-web",
  "tracing-log",

--- a/zeusd/Cargo.toml
+++ b/zeusd/Cargo.toml
@@ -37,6 +37,9 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 futures = "0.3"
 jsonwebtoken = "9"
 humantime = "2"
+regex = "1"
+shell-words = "1"
+toml = "0.8"
 
 [features]
 default = ["nvml", "amdsmi"]

--- a/zeusd/src/config.rs
+++ b/zeusd/src/config.rs
@@ -6,12 +6,13 @@ use serde::{Deserialize, Serialize};
 
 /// API groups that can be independently enabled or disabled.
 ///
-/// Each group maps to a set of HTTP endpoints. Groups that require root
-/// will cause the daemon to exit at startup if it is not running as root.
+/// Each group maps to a set of HTTP endpoints. Groups that require root will
+/// cause the daemon to exit at startup if it is not running as root, unless
+/// GPU command overrides relax the requirement for `gpu-control`.
 ///
 /// Available groups:
 ///   - `gpu-control`: GPU control operations (set power limit, locked clocks,
-///     persistence mode). Requires root.
+///     persistence mode). Requires root unless command overrides are configured.
 ///     - `POST /gpu/set_persistence_mode`
 ///     - `POST /gpu/set_power_limit`
 ///     - `POST /gpu/set_gpu_locked_clocks`
@@ -35,7 +36,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub enum ApiGroup {
     /// GPU control operations (set power limit, clocks, persistence mode).
-    /// Requires root.
+    /// Requires root unless command overrides are configured.
     GpuControl,
     /// GPU read operations (power reading, energy consumption).
     GpuRead,
@@ -45,7 +46,7 @@ pub enum ApiGroup {
 }
 
 impl ApiGroup {
-    /// Whether this API group requires root privileges.
+    /// Whether this API group normally requires root privileges.
     pub fn requires_root(&self) -> bool {
         matches!(self, ApiGroup::GpuControl | ApiGroup::CpuRead)
     }
@@ -170,9 +171,10 @@ pub struct ServeConfig {
     #[clap(long, default_value = "10")]
     pub cpu_power_poll_hz: u32,
 
-    /// API groups to enable. Groups that require root cause the daemon to
-    /// exit at startup if not running as root. Defaults include the API groups
-    /// supported by the platform and compiled device backends.
+    /// API groups to enable. Groups that require root cause the daemon to exit
+    /// at startup if not running as root, unless GPU command overrides are
+    /// configured for `gpu-control`. Defaults include the API groups supported
+    /// by the platform and compiled device backends.
     #[clap(long, value_delimiter = ',')]
     #[cfg_attr(all(target_os = "linux", any(feature = "nvml", feature = "amdsmi")), clap(
         default_values_t = [ApiGroup::GpuControl, ApiGroup::GpuRead, ApiGroup::CpuRead],
@@ -184,6 +186,12 @@ pub struct ServeConfig {
         default_values_t = [ApiGroup::GpuControl, ApiGroup::GpuRead],
     ))]
     pub enable: Vec<ApiGroup>,
+
+    /// Path to a TOML file mapping GPU control operations to external commands
+    /// that are executed instead of the native library call. When at least one
+    /// operation is overridden, the gpu-control API group no longer requires root.
+    #[clap(long)]
+    pub gpu_command_overrides: Option<String>,
 
     /// Path to the HMAC-SHA256 signing key file for JWT authentication.
     /// If not provided, authentication is disabled.

--- a/zeusd/src/config.rs
+++ b/zeusd/src/config.rs
@@ -6,13 +6,12 @@ use serde::{Deserialize, Serialize};
 
 /// API groups that can be independently enabled or disabled.
 ///
-/// Each group maps to a set of HTTP endpoints. Groups that require root will
-/// cause the daemon to exit at startup if it is not running as root, unless
-/// GPU command overrides relax the requirement for `gpu-control`.
+/// Each group maps to a set of HTTP endpoints. Groups that require root
+/// will cause the daemon to exit at startup if it is not running as root.
 ///
 /// Available groups:
 ///   - `gpu-control`: GPU control operations (set power limit, locked clocks,
-///     persistence mode). Requires root unless command overrides are configured.
+///     persistence mode). Requires root.
 ///     - `POST /gpu/set_persistence_mode`
 ///     - `POST /gpu/set_power_limit`
 ///     - `POST /gpu/set_gpu_locked_clocks`
@@ -36,7 +35,7 @@ use serde::{Deserialize, Serialize};
 #[serde(rename_all = "kebab-case")]
 pub enum ApiGroup {
     /// GPU control operations (set power limit, clocks, persistence mode).
-    /// Requires root unless command overrides are configured.
+    /// Requires root.
     GpuControl,
     /// GPU read operations (power reading, energy consumption).
     GpuRead,
@@ -46,7 +45,7 @@ pub enum ApiGroup {
 }
 
 impl ApiGroup {
-    /// Whether this API group normally requires root privileges.
+    /// Whether this API group requires root privileges.
     pub fn requires_root(&self) -> bool {
         matches!(self, ApiGroup::GpuControl | ApiGroup::CpuRead)
     }
@@ -171,10 +170,9 @@ pub struct ServeConfig {
     #[clap(long, default_value = "10")]
     pub cpu_power_poll_hz: u32,
 
-    /// API groups to enable. Groups that require root cause the daemon to exit
-    /// at startup if not running as root, unless GPU command overrides are
-    /// configured for `gpu-control`. Defaults include the API groups supported
-    /// by the platform and compiled device backends.
+    /// API groups to enable. Groups that require root cause the daemon to
+    /// exit at startup if not running as root. Defaults include the API groups
+    /// supported by the platform and compiled device backends.
     #[clap(long, value_delimiter = ',')]
     #[cfg_attr(all(target_os = "linux", any(feature = "nvml", feature = "amdsmi")), clap(
         default_values_t = [ApiGroup::GpuControl, ApiGroup::GpuRead, ApiGroup::CpuRead],

--- a/zeusd/src/devices/gpu/command_override.rs
+++ b/zeusd/src/devices/gpu/command_override.rs
@@ -73,6 +73,7 @@ pub struct GpuCommandOverrides {
 impl GpuCommandOverrides {
     /// Read and validate command overrides from a TOML file.
     pub fn load(path: &str) -> anyhow::Result<Self> {
+        check_file_trust(path)?;
         let contents = std::fs::read_to_string(path)
             .with_context(|| format!("Failed to read GPU command override file '{path}'"))?;
         Self::parse(&contents)
@@ -145,6 +146,48 @@ impl GpuCommandOverrides {
     }
 }
 
+/// The override file decides which commands zeusd executes, and those commands
+/// typically hold passwordless sudo rules. Refuse a file that another user
+/// could have modified.
+#[cfg(unix)]
+fn check_file_trust(path: &str) -> anyhow::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = std::fs::metadata(path)
+        .with_context(|| format!("Failed to read GPU command override file '{path}'"))?;
+    let owner = metadata.uid();
+    let euid = nix::unistd::geteuid().as_raw();
+    if owner != 0 && owner != euid {
+        anyhow::bail!(
+            "GPU command override file '{path}' is owned by uid {owner}; it must be owned by \
+             root or the user running zeusd (uid {euid}) because zeusd executes the commands \
+             it defines"
+        );
+    }
+    let mode = metadata.mode();
+    if mode & 0o002 != 0 {
+        anyhow::bail!(
+            "GPU command override file '{path}' is world-writable (mode {:o}); tighten its \
+             permissions (e.g. chmod 644) because zeusd executes the commands it defines",
+            mode & 0o777
+        );
+    }
+    if mode & 0o020 != 0 {
+        tracing::warn!(
+            "GPU command override file '{}' is group-writable (mode {:o}); anyone in the \
+             group can change which commands zeusd executes",
+            path,
+            mode & 0o777
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn check_file_trust(_path: &str) -> anyhow::Result<()> {
+    Ok(())
+}
+
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawOverrides {
@@ -187,6 +230,13 @@ fn validate_spec(
             })
         })
         .transpose()?;
+
+    if raw.timeout_s == Some(0) {
+        anyhow::bail!(
+            "Operation '{}' has timeout_s = 0, which would kill every command immediately",
+            operation.name()
+        );
+    }
 
     let mut commands = Vec::with_capacity(raw.commands.len());
     for command in raw.commands {
@@ -614,6 +664,7 @@ impl<T: GpuManager> GpuManager for OverriddenGpu<T> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
     use std::sync::atomic::{AtomicUsize, Ordering};
 
     use super::*;
@@ -751,6 +802,33 @@ timeout_s = 7
         let empty_error =
             GpuCommandOverrides::parse("[reset_locked_clocks]\ncommands = [\"\"]\n").unwrap_err();
         assert!(empty_error.to_string().contains("zero tokens"));
+    }
+
+    #[test]
+    fn rejects_zero_timeout() {
+        let error = GpuCommandOverrides::parse(
+            "[set_power_limit]\ncommands = [\"control\"]\ntimeout_s = 0\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("timeout_s = 0"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_world_writable_file_and_accepts_group_writable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("overrides.toml");
+        std::fs::write(&path, "[reset_locked_clocks]\ncommands = [\"control\"]\n").unwrap();
+        let path = path.to_str().unwrap();
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o666)).unwrap();
+        let error = GpuCommandOverrides::load(path).unwrap_err();
+        assert!(error.to_string().contains("world-writable"));
+
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o664)).unwrap();
+        GpuCommandOverrides::load(path).unwrap();
     }
 
     #[test]
@@ -948,11 +1026,13 @@ timeout_s = 7
         assert!(!marker.exists());
     }
 
+    #[cfg(unix)]
     struct MockGpu {
         power_limit_calls: Arc<AtomicUsize>,
         gpu_clock_calls: Arc<AtomicUsize>,
     }
 
+    #[cfg(unix)]
     impl GpuManager for MockGpu {
         fn device_count() -> Result<u32, ZeusdError> {
             Ok(1)

--- a/zeusd/src/devices/gpu/command_override.rs
+++ b/zeusd/src/devices/gpu/command_override.rs
@@ -1,0 +1,1063 @@
+//! External command overrides for privileged GPU control operations.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::process::{Command, Stdio};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::Context;
+use regex::Regex;
+use serde::Deserialize;
+
+use super::GpuManager;
+use crate::error::ZeusdError;
+
+const DEFAULT_TIMEOUT_S: u64 = 60;
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+const OUTPUT_COLLECTION_GRACE: Duration = Duration::from_secs(1);
+
+/// A GPU control operation that can be replaced by external commands.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum GpuControlOperation {
+    SetPersistenceMode,
+    SetPowerLimit,
+    SetGpuLockedClocks,
+    ResetGpuLockedClocks,
+    SetMemLockedClocks,
+    ResetMemLockedClocks,
+    ResetLockedClocks,
+}
+
+impl GpuControlOperation {
+    fn name(self) -> &'static str {
+        match self {
+            Self::SetPersistenceMode => "set_persistence_mode",
+            Self::SetPowerLimit => "set_power_limit",
+            Self::SetGpuLockedClocks => "set_gpu_locked_clocks",
+            Self::ResetGpuLockedClocks => "reset_gpu_locked_clocks",
+            Self::SetMemLockedClocks => "set_mem_locked_clocks",
+            Self::ResetMemLockedClocks => "reset_mem_locked_clocks",
+            Self::ResetLockedClocks => "reset_locked_clocks",
+        }
+    }
+
+    fn allowed_placeholders(self) -> &'static [&'static str] {
+        match self {
+            Self::SetPersistenceMode => &["gpu_id", "enabled"],
+            Self::SetPowerLimit => &["gpu_id", "power_limit_mw", "power_limit_w"],
+            Self::SetGpuLockedClocks | Self::SetMemLockedClocks => {
+                &["gpu_id", "min_clock_mhz", "max_clock_mhz"]
+            }
+            Self::ResetGpuLockedClocks | Self::ResetMemLockedClocks | Self::ResetLockedClocks => {
+                &["gpu_id"]
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct OverrideSpec {
+    commands: Vec<Vec<String>>,
+    error_pattern: Option<Regex>,
+    timeout: Duration,
+}
+
+/// Parsed and validated external command overrides.
+#[derive(Debug)]
+pub struct GpuCommandOverrides {
+    specs: HashMap<GpuControlOperation, OverrideSpec>,
+}
+
+impl GpuCommandOverrides {
+    /// Read and validate command overrides from a TOML file.
+    pub fn load(path: &str) -> anyhow::Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("Failed to read GPU command override file '{path}'"))?;
+        Self::parse(&contents)
+            .with_context(|| format!("Failed to parse GPU command override file '{path}'"))
+    }
+
+    fn parse(contents: &str) -> anyhow::Result<Self> {
+        let raw: RawOverrides = toml::from_str(contents)?;
+        let entries = [
+            (
+                GpuControlOperation::SetPersistenceMode,
+                raw.set_persistence_mode,
+            ),
+            (GpuControlOperation::SetPowerLimit, raw.set_power_limit),
+            (
+                GpuControlOperation::SetGpuLockedClocks,
+                raw.set_gpu_locked_clocks,
+            ),
+            (
+                GpuControlOperation::ResetGpuLockedClocks,
+                raw.reset_gpu_locked_clocks,
+            ),
+            (
+                GpuControlOperation::SetMemLockedClocks,
+                raw.set_mem_locked_clocks,
+            ),
+            (
+                GpuControlOperation::ResetMemLockedClocks,
+                raw.reset_mem_locked_clocks,
+            ),
+            (
+                GpuControlOperation::ResetLockedClocks,
+                raw.reset_locked_clocks,
+            ),
+        ];
+        let mut specs = HashMap::new();
+        for (operation, raw_spec) in entries {
+            if let Some(raw_spec) = raw_spec {
+                specs.insert(operation, validate_spec(operation, raw_spec)?);
+            }
+        }
+        Ok(Self { specs })
+    }
+
+    /// Return the configured operation names in declaration order.
+    pub fn overridden_operation_names(&self) -> Vec<&'static str> {
+        const OPERATIONS: [GpuControlOperation; 7] = [
+            GpuControlOperation::SetPersistenceMode,
+            GpuControlOperation::SetPowerLimit,
+            GpuControlOperation::SetGpuLockedClocks,
+            GpuControlOperation::ResetGpuLockedClocks,
+            GpuControlOperation::SetMemLockedClocks,
+            GpuControlOperation::ResetMemLockedClocks,
+            GpuControlOperation::ResetLockedClocks,
+        ];
+        OPERATIONS
+            .iter()
+            .filter(|operation| self.specs.contains_key(operation))
+            .map(|operation| operation.name())
+            .collect()
+    }
+
+    /// Return whether at least one operation is overridden.
+    pub fn is_empty(&self) -> bool {
+        self.specs.is_empty()
+    }
+
+    fn get(&self, operation: GpuControlOperation) -> Option<&OverrideSpec> {
+        self.specs.get(&operation)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawOverrides {
+    set_persistence_mode: Option<RawOverrideSpec>,
+    set_power_limit: Option<RawOverrideSpec>,
+    set_gpu_locked_clocks: Option<RawOverrideSpec>,
+    reset_gpu_locked_clocks: Option<RawOverrideSpec>,
+    set_mem_locked_clocks: Option<RawOverrideSpec>,
+    reset_mem_locked_clocks: Option<RawOverrideSpec>,
+    reset_locked_clocks: Option<RawOverrideSpec>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawOverrideSpec {
+    commands: Vec<String>,
+    error_pattern: Option<String>,
+    timeout_s: Option<u64>,
+}
+
+fn validate_spec(
+    operation: GpuControlOperation,
+    raw: RawOverrideSpec,
+) -> anyhow::Result<OverrideSpec> {
+    if raw.commands.is_empty() {
+        anyhow::bail!(
+            "Operation '{}' has an empty commands array",
+            operation.name()
+        );
+    }
+
+    let error_pattern = raw
+        .error_pattern
+        .map(|pattern| {
+            Regex::new(&pattern).with_context(|| {
+                format!(
+                    "Operation '{}' has invalid error_pattern '{pattern}'",
+                    operation.name()
+                )
+            })
+        })
+        .transpose()?;
+
+    let mut commands = Vec::with_capacity(raw.commands.len());
+    for command in raw.commands {
+        let tokens = shell_words::split(&command).with_context(|| {
+            format!(
+                "Operation '{}' has a command that cannot be split: {command}",
+                operation.name()
+            )
+        })?;
+        if tokens.is_empty() {
+            anyhow::bail!(
+                "Operation '{}' has a command that splits to zero tokens",
+                operation.name()
+            );
+        }
+        for token in &tokens {
+            validate_placeholders(operation, token)?;
+        }
+        commands.push(tokens);
+    }
+
+    Ok(OverrideSpec {
+        commands,
+        error_pattern,
+        timeout: Duration::from_secs(raw.timeout_s.unwrap_or(DEFAULT_TIMEOUT_S)),
+    })
+}
+
+fn validate_placeholders(operation: GpuControlOperation, token: &str) -> anyhow::Result<()> {
+    let bytes = token.as_bytes();
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'{' => {
+                let name_start = index + 1;
+                let mut end = name_start;
+                while end < bytes.len() && bytes[end] != b'{' && bytes[end] != b'}' {
+                    end += 1;
+                }
+                if end == bytes.len() || bytes[end] != b'}' || end == name_start {
+                    anyhow::bail!(
+                        "Operation '{}' has an invalid placeholder in token '{}'",
+                        operation.name(),
+                        token
+                    );
+                }
+                let name = &token[name_start..end];
+                if !operation.allowed_placeholders().contains(&name) {
+                    anyhow::bail!(
+                        "Operation '{}' has unknown placeholder '{{{}}}' in token '{}'",
+                        operation.name(),
+                        name,
+                        token
+                    );
+                }
+                index = end + 1;
+            }
+            b'}' => {
+                anyhow::bail!(
+                    "Operation '{}' has an invalid placeholder in token '{}'",
+                    operation.name(),
+                    token
+                );
+            }
+            _ => index += 1,
+        }
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct PlaceholderValues {
+    gpu_id: usize,
+    enabled: Option<bool>,
+    power_limit_mw: Option<u32>,
+    min_clock_mhz: Option<u32>,
+    max_clock_mhz: Option<u32>,
+}
+
+impl PlaceholderValues {
+    fn substitute(&self, token: &str) -> String {
+        let mut result = token.replace("{gpu_id}", &self.gpu_id.to_string());
+        if let Some(enabled) = self.enabled {
+            result = result.replace("{enabled}", if enabled { "1" } else { "0" });
+        }
+        if let Some(power_limit_mw) = self.power_limit_mw {
+            result = result.replace("{power_limit_mw}", &power_limit_mw.to_string());
+            result = result.replace("{power_limit_w}", &(power_limit_mw / 1000).to_string());
+        }
+        if let Some(min_clock_mhz) = self.min_clock_mhz {
+            result = result.replace("{min_clock_mhz}", &min_clock_mhz.to_string());
+        }
+        if let Some(max_clock_mhz) = self.max_clock_mhz {
+            result = result.replace("{max_clock_mhz}", &max_clock_mhz.to_string());
+        }
+        result
+    }
+}
+
+fn execute_override(spec: &OverrideSpec, values: &PlaceholderValues) -> Result<(), ZeusdError> {
+    for command in &spec.commands {
+        let command: Vec<String> = command
+            .iter()
+            .map(|token| values.substitute(token))
+            .collect();
+        execute_command(&command, spec)?;
+    }
+    Ok(())
+}
+
+fn execute_command(command: &[String], spec: &OverrideSpec) -> Result<(), ZeusdError> {
+    let command_line = shell_words::join(command);
+    let child_result = Command::new(&command[0])
+        .args(&command[1..])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn();
+    let mut child = match child_result {
+        Ok(child) => child,
+        Err(error) => {
+            let reason = format!("could not be spawned: {error}");
+            tracing::info!(command = %command_line, outcome = %reason, "GPU override command completed");
+            return Err(command_error(&command_line, &reason, "", ""));
+        }
+    };
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| command_error(&command_line, "stdout capture was unavailable", "", ""))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| command_error(&command_line, "stderr capture was unavailable", "", ""))?;
+    let stdout_rx = spawn_pipe_reader(stdout);
+    let stderr_rx = spawn_pipe_reader(stderr);
+    let started = Instant::now();
+
+    let outcome = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break CommandOutcome::Exited(status),
+            Ok(None) if started.elapsed() >= spec.timeout => {
+                let kill_result = child.kill();
+                let wait_result = child.wait();
+                break CommandOutcome::TimedOut {
+                    kill_result,
+                    wait_result,
+                };
+            }
+            Ok(None) => thread::sleep(POLL_INTERVAL),
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break CommandOutcome::WaitError(error);
+            }
+        }
+    };
+
+    let stdout = collect_pipe(stdout_rx, "stdout");
+    let stderr = collect_pipe(stderr_rx, "stderr");
+
+    let failure = match outcome {
+        CommandOutcome::Exited(status) if !status.success() => Some(describe_exit(status)),
+        CommandOutcome::Exited(_) => match (&spec.error_pattern, &stdout, &stderr) {
+            (None, _, _) => None,
+            (Some(pattern), Ok(stdout), Ok(stderr)) => {
+                let mut output = String::with_capacity(stdout.len() + stderr.len());
+                output.push_str(stdout);
+                output.push_str(stderr);
+                pattern.is_match(&output).then(|| {
+                    format!(
+                        "succeeded but its output matched error_pattern '{}'",
+                        pattern.as_str()
+                    )
+                })
+            }
+            (Some(_), _, _) => Some(
+                "succeeded but its output could not be collected, so error_pattern could not \
+                 be checked"
+                    .to_string(),
+            ),
+        },
+        CommandOutcome::TimedOut {
+            kill_result,
+            wait_result,
+        } => {
+            if let Err(error) = kill_result {
+                Some(format!(
+                    "timed out after {}s and could not be killed: {error}",
+                    spec.timeout.as_secs()
+                ))
+            } else if let Err(error) = wait_result {
+                Some(format!(
+                    "timed out after {}s and could not be reaped: {error}",
+                    spec.timeout.as_secs()
+                ))
+            } else {
+                Some(format!("timed out after {}s", spec.timeout.as_secs()))
+            }
+        }
+        CommandOutcome::WaitError(error) => Some(format!("could not be waited on: {error}")),
+    };
+
+    if let Some(reason) = failure {
+        let stdout = stdout.unwrap_or_else(|reason| format!("<{reason}>"));
+        let stderr = stderr.unwrap_or_else(|reason| format!("<{reason}>"));
+        tracing::info!(command = %command_line, outcome = %reason, "GPU override command completed");
+        return Err(command_error(&command_line, &reason, &stdout, &stderr));
+    }
+    tracing::info!(command = %command_line, outcome = "success", "GPU override command completed");
+    Ok(())
+}
+
+fn describe_exit(status: std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => format!("exited with code {code}"),
+        None => format!("was terminated abnormally ({status})"),
+    }
+}
+
+enum CommandOutcome {
+    Exited(std::process::ExitStatus),
+    TimedOut {
+        kill_result: std::io::Result<()>,
+        wait_result: std::io::Result<std::process::ExitStatus>,
+    },
+    WaitError(std::io::Error),
+}
+
+fn drain_pipe<R: Read>(mut pipe: R) -> std::io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    pipe.read_to_end(&mut output)?;
+    Ok(output)
+}
+
+fn spawn_pipe_reader<R: Read + Send + 'static>(
+    pipe: R,
+) -> std::sync::mpsc::Receiver<std::io::Result<Vec<u8>>> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    thread::spawn(move || {
+        let _ = tx.send(drain_pipe(pipe));
+    });
+    rx
+}
+
+/// Wait for a pipe reader with a bounded grace period instead of joining it.
+/// The reader only returns once every write end of the pipe is closed, and a
+/// process spawned by the command (e.g., sudo's child, which survives the kill
+/// of sudo itself on timeout) can hold the pipe open indefinitely; joining
+/// would then block this GPU's management task forever.
+fn collect_pipe(
+    rx: std::sync::mpsc::Receiver<std::io::Result<Vec<u8>>>,
+    stream: &str,
+) -> Result<String, String> {
+    match rx.recv_timeout(OUTPUT_COLLECTION_GRACE) {
+        Ok(Ok(bytes)) => Ok(String::from_utf8_lossy(&bytes).into_owned()),
+        Ok(Err(error)) => Err(format!("{stream} could not be read: {error}")),
+        Err(_) => Err(format!(
+            "{stream} was still open {}s after the command ended, likely held by a \
+             leftover child process",
+            OUTPUT_COLLECTION_GRACE.as_secs()
+        )),
+    }
+}
+
+fn command_error(command_line: &str, reason: &str, stdout: &str, stderr: &str) -> ZeusdError {
+    ZeusdError::CommandOverrideError(format!(
+        "command '{command_line}' {reason}; stdout: {stdout}; stderr: {stderr}"
+    ))
+}
+
+/// A GPU manager that executes configured control operations as commands.
+pub struct OverriddenGpu<T: GpuManager> {
+    gpu_id: usize,
+    inner: T,
+    overrides: Arc<GpuCommandOverrides>,
+}
+
+impl<T: GpuManager> OverriddenGpu<T> {
+    /// Wrap a native GPU manager with command overrides.
+    pub fn new(gpu_id: usize, inner: T, overrides: Arc<GpuCommandOverrides>) -> Self {
+        Self {
+            gpu_id,
+            inner,
+            overrides,
+        }
+    }
+
+    fn execute(
+        &self,
+        operation: GpuControlOperation,
+        values: PlaceholderValues,
+    ) -> Option<Result<(), ZeusdError>> {
+        self.overrides
+            .get(operation)
+            .map(|spec| execute_override(spec, &values))
+    }
+}
+
+impl<T: GpuManager> GpuManager for OverriddenGpu<T> {
+    fn device_count() -> Result<u32, ZeusdError>
+    where
+        Self: Sized,
+    {
+        T::device_count()
+    }
+
+    fn set_persistence_mode(&mut self, enabled: bool) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::SetPersistenceMode,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                enabled: Some(enabled),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| self.inner.set_persistence_mode(enabled))
+    }
+
+    fn get_persistence_mode(&mut self) -> Result<bool, ZeusdError> {
+        self.inner.get_persistence_mode()
+    }
+
+    fn set_power_management_limit(&mut self, power_limit_mw: u32) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::SetPowerLimit,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                power_limit_mw: Some(power_limit_mw),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| self.inner.set_power_management_limit(power_limit_mw))
+    }
+
+    fn get_power_management_limit(&mut self) -> Result<u32, ZeusdError> {
+        self.inner.get_power_management_limit()
+    }
+
+    fn get_power_management_limit_constraints(&mut self) -> Result<(u32, u32), ZeusdError> {
+        self.inner.get_power_management_limit_constraints()
+    }
+
+    fn set_gpu_locked_clocks(
+        &mut self,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::SetGpuLockedClocks,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                min_clock_mhz: Some(min_clock_mhz),
+                max_clock_mhz: Some(max_clock_mhz),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| {
+            self.inner
+                .set_gpu_locked_clocks(min_clock_mhz, max_clock_mhz)
+        })
+    }
+
+    fn reset_gpu_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::ResetGpuLockedClocks,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| self.inner.reset_gpu_locked_clocks())
+    }
+
+    fn set_mem_locked_clocks(
+        &mut self,
+        min_clock_mhz: u32,
+        max_clock_mhz: u32,
+    ) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::SetMemLockedClocks,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                min_clock_mhz: Some(min_clock_mhz),
+                max_clock_mhz: Some(max_clock_mhz),
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| {
+            self.inner
+                .set_mem_locked_clocks(min_clock_mhz, max_clock_mhz)
+        })
+    }
+
+    fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::ResetMemLockedClocks,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| self.inner.reset_mem_locked_clocks())
+    }
+
+    fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+        self.execute(
+            GpuControlOperation::ResetLockedClocks,
+            PlaceholderValues {
+                gpu_id: self.gpu_id,
+                ..Default::default()
+            },
+        )
+        .unwrap_or_else(|| self.inner.reset_locked_clocks())
+    }
+
+    fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {
+        self.inner.get_instant_power_mw()
+    }
+
+    fn get_total_energy_consumption(&mut self) -> Result<u64, ZeusdError> {
+        self.inner.get_total_energy_consumption()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use super::*;
+
+    fn parse_single(operation: &str, body: &str) -> GpuCommandOverrides {
+        GpuCommandOverrides::parse(&format!("[{operation}]\n{body}")).unwrap()
+    }
+
+    #[test]
+    fn loads_valid_config_with_all_operations_and_fields() {
+        let contents = r#"
+[set_persistence_mode]
+commands = ["control --gpu={gpu_id} --enabled={enabled}"]
+error_pattern = "(?i)error"
+timeout_s = 1
+
+[set_power_limit]
+commands = ["control {gpu_id} {power_limit_mw} {power_limit_w}"]
+error_pattern = "failed"
+timeout_s = 2
+
+[set_gpu_locked_clocks]
+commands = ["control {gpu_id} {min_clock_mhz} {max_clock_mhz}"]
+error_pattern = "failed"
+timeout_s = 3
+
+[reset_gpu_locked_clocks]
+commands = ["control {gpu_id}"]
+error_pattern = "failed"
+timeout_s = 4
+
+[set_mem_locked_clocks]
+commands = ["control {gpu_id} {min_clock_mhz} {max_clock_mhz}"]
+error_pattern = "failed"
+timeout_s = 5
+
+[reset_mem_locked_clocks]
+commands = ["control {gpu_id}"]
+error_pattern = "failed"
+timeout_s = 6
+
+[reset_locked_clocks]
+commands = ["control {gpu_id}"]
+error_pattern = "failed"
+timeout_s = 7
+"#;
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("overrides.toml");
+        std::fs::write(&path, contents).unwrap();
+        let config = GpuCommandOverrides::load(path.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            config.overridden_operation_names(),
+            vec![
+                "set_persistence_mode",
+                "set_power_limit",
+                "set_gpu_locked_clocks",
+                "reset_gpu_locked_clocks",
+                "set_mem_locked_clocks",
+                "reset_mem_locked_clocks",
+                "reset_locked_clocks",
+            ]
+        );
+        assert_eq!(
+            config
+                .get(GpuControlOperation::ResetLockedClocks)
+                .unwrap()
+                .timeout,
+            Duration::from_secs(7)
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_operation() {
+        let error =
+            GpuCommandOverrides::parse("[set_fan_speed]\ncommands = [\"control {gpu_id}\"]\n")
+                .unwrap_err();
+        assert!(error.to_string().contains("unknown field `set_fan_speed`"));
+    }
+
+    #[test]
+    fn rejects_unknown_operation_field() {
+        let error = GpuCommandOverrides::parse(
+            "[set_power_limit]\ncommands = [\"control\"]\nworking_dir = \"/tmp\"\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unknown field `working_dir`"));
+    }
+
+    #[test]
+    fn rejects_empty_commands() {
+        let error = GpuCommandOverrides::parse("[set_power_limit]\ncommands = []\n").unwrap_err();
+        assert!(error.to_string().contains("empty commands array"));
+    }
+
+    #[test]
+    fn rejects_invalid_regex() {
+        let error = GpuCommandOverrides::parse(
+            "[set_power_limit]\ncommands = [\"control\"]\nerror_pattern = \"[\"\n",
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("set_power_limit"));
+        assert!(error.to_string().contains("invalid error_pattern"));
+    }
+
+    #[test]
+    fn rejects_unknown_placeholder_with_operation_and_token() {
+        let error = GpuCommandOverrides::parse(
+            "[set_power_limit]\ncommands = [\"control --value={max_clock_mhz}\"]\n",
+        )
+        .unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("set_power_limit"));
+        assert!(message.contains("--value={max_clock_mhz}"));
+    }
+
+    #[test]
+    fn rejects_stray_or_unmatched_braces() {
+        for token in ["value}", "{gpu_id", "{{gpu_id}"] {
+            let input = format!("[reset_locked_clocks]\ncommands = [\"control {token}\"]\n");
+            let error = GpuCommandOverrides::parse(&input).unwrap_err();
+            let message = error.to_string();
+            assert!(message.contains("reset_locked_clocks"));
+            assert!(message.contains(token));
+        }
+    }
+
+    #[test]
+    fn rejects_commands_that_cannot_be_split_or_have_no_tokens() {
+        let split_error =
+            GpuCommandOverrides::parse("[reset_locked_clocks]\ncommands = [\"control '\"]\n")
+                .unwrap_err();
+        assert!(split_error.to_string().contains("cannot be split"));
+
+        let empty_error =
+            GpuCommandOverrides::parse("[reset_locked_clocks]\ncommands = [\"\"]\n").unwrap_err();
+        assert!(empty_error.to_string().contains("zero tokens"));
+    }
+
+    #[test]
+    fn substitutes_all_operation_values() {
+        let power = PlaceholderValues {
+            gpu_id: 3,
+            power_limit_mw: Some(253_999),
+            ..Default::default()
+        };
+        assert_eq!(
+            power.substitute("--gpu={gpu_id}:{power_limit_mw}:{power_limit_w}"),
+            "--gpu=3:253999:253"
+        );
+
+        let clocks = PlaceholderValues {
+            gpu_id: 4,
+            min_clock_mhz: Some(500),
+            max_clock_mhz: Some(1_700),
+            ..Default::default()
+        };
+        assert_eq!(
+            clocks.substitute("{gpu_id}:{min_clock_mhz}:{max_clock_mhz}"),
+            "4:500:1700"
+        );
+
+        let enabled = PlaceholderValues {
+            gpu_id: 5,
+            enabled: Some(true),
+            ..Default::default()
+        };
+        assert_eq!(enabled.substitute("{gpu_id}:{enabled}"), "5:1");
+        let disabled = PlaceholderValues {
+            enabled: Some(false),
+            ..Default::default()
+        };
+        assert_eq!(disabled.substitute("{enabled}"), "0");
+    }
+
+    #[cfg(unix)]
+    fn write_script(directory: &std::path::Path, name: &str, body: &str) -> String {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = directory.join(name);
+        std::fs::write(&path, format!("#!/bin/sh\n{body}\n")).unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        path.to_string_lossy().into_owned()
+    }
+
+    #[cfg(unix)]
+    fn spec_for_command(command: &str, extra: &str) -> GpuCommandOverrides {
+        GpuCommandOverrides::parse(&format!(
+            "[reset_locked_clocks]\ncommands = [{}]\n{extra}",
+            toml::Value::String(command.to_string())
+        ))
+        .unwrap()
+    }
+
+    #[cfg(unix)]
+    fn execute_reset(config: &GpuCommandOverrides) -> Result<(), ZeusdError> {
+        execute_override(
+            config.get(GpuControlOperation::ResetLockedClocks).unwrap(),
+            &PlaceholderValues::default(),
+        )
+    }
+
+    /// Serialize tests that write scripts and spawn them. A concurrent fork in
+    /// another test inherits a script file descriptor that is still open for
+    /// writing, and executing that script then fails with ETXTBSY.
+    #[cfg(unix)]
+    fn subprocess_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_succeeds_for_zero_exit_without_pattern_match() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(directory.path(), "success.sh", "echo success");
+        let config = spec_for_command(&script, "");
+        execute_reset(&config).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_rejects_nonzero_exit_and_captures_output() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(
+            directory.path(),
+            "failure.sh",
+            "echo standard-output\necho standard-error >&2\nexit 7",
+        );
+        let error = execute_reset(&spec_for_command(&script, "")).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("exited with code 7"), "{message}");
+        assert!(message.contains("standard-output"));
+        assert!(message.contains("standard-error"));
+        assert!(message.contains(&script));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_rejects_error_pattern_match_after_zero_exit() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(directory.path(), "pattern.sh", "echo ERROR >&2");
+        let config = spec_for_command(&script, "error_pattern = \"(?i)error\"\n");
+        let error = execute_reset(&config).unwrap_err();
+        assert!(error.to_string().contains("matched error_pattern"));
+        assert!(error.to_string().contains("ERROR"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_kills_and_reaps_timed_out_command() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(directory.path(), "timeout.sh", "exec sleep 30");
+        let config = spec_for_command(&script, "timeout_s = 1\n");
+        let started = Instant::now();
+        let error = execute_reset(&config).unwrap_err();
+        assert!(error.to_string().contains("timed out after 1s"));
+        assert!(started.elapsed() < Duration::from_secs(10));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_does_not_block_on_pipes_held_by_leftover_children() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(directory.path(), "linger.sh", "sleep 30 &\nexit 0");
+
+        let started = Instant::now();
+        execute_reset(&spec_for_command(&script, "")).unwrap();
+        assert!(started.elapsed() < Duration::from_secs(10));
+
+        let started = Instant::now();
+        let error = execute_reset(&spec_for_command(
+            &script,
+            "error_pattern = \"(?i)error\"\n",
+        ))
+        .unwrap_err();
+        assert!(started.elapsed() < Duration::from_secs(10));
+        assert!(error
+            .to_string()
+            .contains("output could not be collected, so error_pattern could not be checked"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_timeout_is_not_extended_by_surviving_grandchildren() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let script = write_script(directory.path(), "orphan.sh", "sleep 30 &\nexec sleep 30");
+        let config = spec_for_command(&script, "timeout_s = 1\n");
+        let started = Instant::now();
+        let error = execute_reset(&config).unwrap_err();
+        assert!(error.to_string().contains("timed out after 1s"));
+        assert!(started.elapsed() < Duration::from_secs(10));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_rejects_spawn_failure() {
+        let _guard = subprocess_lock();
+        let missing = "/nonexistent/zeusd-command-override-test";
+        let error = execute_reset(&spec_for_command(missing, "")).unwrap_err();
+        assert!(error.to_string().contains("could not be spawned"));
+        assert!(error.to_string().contains(missing));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn executor_stops_after_first_failure() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let marker = directory.path().join("marker");
+        let failure = write_script(directory.path(), "first.sh", "exit 1");
+        let second = write_script(
+            directory.path(),
+            "second.sh",
+            &format!("touch {}", marker.display()),
+        );
+        let config = GpuCommandOverrides::parse(&format!(
+            "[reset_locked_clocks]\ncommands = [{}, {}]\n",
+            toml::Value::String(failure),
+            toml::Value::String(second)
+        ))
+        .unwrap();
+        execute_reset(&config).unwrap_err();
+        assert!(!marker.exists());
+    }
+
+    struct MockGpu {
+        power_limit_calls: Arc<AtomicUsize>,
+        gpu_clock_calls: Arc<AtomicUsize>,
+    }
+
+    impl GpuManager for MockGpu {
+        fn device_count() -> Result<u32, ZeusdError> {
+            Ok(1)
+        }
+
+        fn set_persistence_mode(&mut self, _enabled: bool) -> Result<(), ZeusdError> {
+            Ok(())
+        }
+
+        fn get_persistence_mode(&mut self) -> Result<bool, ZeusdError> {
+            Ok(true)
+        }
+
+        fn set_power_management_limit(&mut self, _power_limit: u32) -> Result<(), ZeusdError> {
+            self.power_limit_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn get_power_management_limit(&mut self) -> Result<u32, ZeusdError> {
+            Ok(200_000)
+        }
+
+        fn get_power_management_limit_constraints(&mut self) -> Result<(u32, u32), ZeusdError> {
+            Ok((100_000, 300_000))
+        }
+
+        fn set_gpu_locked_clocks(
+            &mut self,
+            _min_clock_mhz: u32,
+            _max_clock_mhz: u32,
+        ) -> Result<(), ZeusdError> {
+            self.gpu_clock_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        fn reset_gpu_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+            Ok(())
+        }
+
+        fn set_mem_locked_clocks(
+            &mut self,
+            _min_clock_mhz: u32,
+            _max_clock_mhz: u32,
+        ) -> Result<(), ZeusdError> {
+            Ok(())
+        }
+
+        fn reset_mem_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+            Ok(())
+        }
+
+        fn reset_locked_clocks(&mut self) -> Result<(), ZeusdError> {
+            Ok(())
+        }
+
+        fn get_instant_power_mw(&mut self) -> Result<u32, ZeusdError> {
+            Ok(150_000)
+        }
+
+        fn get_total_energy_consumption(&mut self) -> Result<u64, ZeusdError> {
+            Ok(1_000)
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn wrapper_executes_overrides_and_delegates_other_operations() {
+        let _guard = subprocess_lock();
+        let directory = tempfile::tempdir().unwrap();
+        let marker = directory.path().join("marker");
+        let script = write_script(
+            directory.path(),
+            "marker.sh",
+            &format!("echo \"$1:$2\" > {}", marker.display()),
+        );
+        let config = GpuCommandOverrides::parse(&format!(
+            "[set_power_limit]\ncommands = [{}]\n",
+            toml::Value::String(format!("{script} {{gpu_id}} {{power_limit_w}}"))
+        ))
+        .unwrap();
+        let power_limit_calls = Arc::new(AtomicUsize::new(0));
+        let gpu_clock_calls = Arc::new(AtomicUsize::new(0));
+        let inner = MockGpu {
+            power_limit_calls: power_limit_calls.clone(),
+            gpu_clock_calls: gpu_clock_calls.clone(),
+        };
+        let mut gpu = OverriddenGpu::new(7, inner, Arc::new(config));
+
+        gpu.set_power_management_limit(251_999).unwrap();
+        assert_eq!(std::fs::read_to_string(marker).unwrap().trim(), "7:251");
+        assert_eq!(power_limit_calls.load(Ordering::SeqCst), 0);
+
+        gpu.set_gpu_locked_clocks(500, 1_500).unwrap();
+        assert_eq!(gpu_clock_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn defaults_timeout_to_sixty_seconds() {
+        let config = parse_single("reset_locked_clocks", "commands = [\"control\"]\n");
+        assert_eq!(
+            config
+                .get(GpuControlOperation::ResetLockedClocks)
+                .unwrap()
+                .timeout,
+            Duration::from_secs(60)
+        );
+    }
+}

--- a/zeusd/src/devices/gpu/mod.rs
+++ b/zeusd/src/devices/gpu/mod.rs
@@ -1,5 +1,6 @@
 //! GPU management
 
+pub mod command_override;
 #[cfg(feature = "nvml")]
 pub(crate) mod nvml;
 #[cfg(feature = "nvml")]

--- a/zeusd/src/error.rs
+++ b/zeusd/src/error.rs
@@ -58,6 +58,8 @@ pub enum ZeusdError {
     Forbidden(String),
     #[error("Persistence mode cannot be disabled on this platform.")]
     PersistenceModeCannotBeDisabled,
+    #[error("Override command failed: {0}")]
+    CommandOverrideError(String),
 }
 
 /// This allows us to return a custom HTTP status code for each error variant.
@@ -92,6 +94,7 @@ impl ResponseError for ZeusdError {
             ZeusdError::Unauthorized => StatusCode::UNAUTHORIZED,
             ZeusdError::Forbidden(_) => StatusCode::FORBIDDEN,
             ZeusdError::PersistenceModeCannotBeDisabled => StatusCode::BAD_REQUEST,
+            ZeusdError::CommandOverrideError(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
 }

--- a/zeusd/src/main.rs
+++ b/zeusd/src/main.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use zeusd::auth::{issue_token, SigningKeyData};
 use zeusd::config::{get_cli, ApiGroup, Command, ConnectionMode, TokenCommand};
+use zeusd::devices::gpu::command_override::GpuCommandOverrides;
 use zeusd::routes::CpuPowerSamplingPeriod;
 use zeusd::routes::DiscoveryInfo;
 #[cfg(windows)]
@@ -56,6 +57,17 @@ fn handle_token_command(action: TokenCommand) -> anyhow::Result<()> {
 async fn handle_serve(config: zeusd::config::ServeConfig) -> anyhow::Result<()> {
     tracing::info!("Loaded {:?}", config);
 
+    let mut gpu_command_overrides = match &config.gpu_command_overrides {
+        Some(path) => Some(Arc::new(GpuCommandOverrides::load(path)?)),
+        None => None,
+    };
+    if gpu_command_overrides.is_some() && !config.is_enabled(ApiGroup::GpuControl) {
+        tracing::warn!(
+            "GPU command overrides are ignored because the gpu-control API group is not enabled"
+        );
+        gpu_command_overrides = None;
+    }
+
     let resolved_gpu_backend = if config.needs_gpu() {
         Some(resolve_gpu_backend(config.gpu_backend)?)
     } else {
@@ -63,7 +75,7 @@ async fn handle_serve(config: zeusd::config::ServeConfig) -> anyhow::Result<()> 
     };
 
     // Validate privileges for the requested API groups.
-    check_privileges(&config.enable)?;
+    check_privileges(&config.enable, gpu_command_overrides.as_deref())?;
 
     let enabled_groups = EnabledGroups(config.enable.iter().cloned().collect());
     tracing::info!(
@@ -99,7 +111,7 @@ async fn handle_serve(config: zeusd::config::ServeConfig) -> anyhow::Result<()> 
     // Conditionally initialize GPU devices.
     let (gpu_device_tasks, gpu_power_broadcast, gpus) = if config.needs_gpu() {
         let backend = resolved_gpu_backend.expect("GPU backend must be resolved");
-        let (tasks, gpus) = start_gpu_device_tasks(backend)?;
+        let (tasks, gpus) = start_gpu_device_tasks(backend, gpu_command_overrides.clone())?;
         let broadcast = if config.is_enabled(ApiGroup::GpuRead) {
             Some(start_gpu_power_poller(backend, config.gpu_power_poll_hz)?)
         } else {

--- a/zeusd/src/startup.rs
+++ b/zeusd/src/startup.rs
@@ -301,6 +301,8 @@ pub fn start_gpu_device_tasks(
     backend: ResolvedGpuBackend,
     overrides: Option<Arc<GpuCommandOverrides>>,
 ) -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
+    // Suppresses the unused-variable warning when no GPU backend feature is
+    // compiled and only the `None` match arm remains.
     let _ = &overrides;
     match backend {
         #[cfg(feature = "nvml")]
@@ -443,22 +445,19 @@ pub fn check_privileges(
         let is_root = nix::unistd::geteuid().is_root();
         for &group in enabled_groups {
             if group.requires_root() && !is_root {
-                if group == ApiGroup::GpuControl && overrides.is_some_and(|value| !value.is_empty())
-                {
-                    let operation_names = overrides
-                        .expect("nonempty overrides were checked")
-                        .overridden_operation_names()
-                        .join(", ");
-                    tracing::info!(
-                        "API group 'gpu-control' is enabled without root because command overrides \
-                         are configured for: {}",
-                        operation_names,
-                    );
-                    tracing::warn!(
-                        "GPU control operations without a command override will use the native \
-                         driver path and may fail with permission errors."
-                    );
-                    continue;
+                if let Some(overrides) = overrides.filter(|value| !value.is_empty()) {
+                    if group == ApiGroup::GpuControl {
+                        tracing::info!(
+                            "API group 'gpu-control' is enabled without root because command \
+                             overrides are configured for: {}",
+                            overrides.overridden_operation_names().join(", "),
+                        );
+                        tracing::warn!(
+                            "GPU control operations without a command override will use the \
+                             native driver path and may fail with permission errors."
+                        );
+                        continue;
+                    }
                 }
                 tracing::error!(
                     "API group '{}' requires root privileges. \

--- a/zeusd/src/startup.rs
+++ b/zeusd/src/startup.rs
@@ -14,6 +14,7 @@ use std::os::unix::fs::{chown, PermissionsExt};
 use std::os::unix::net::UnixListener;
 #[cfg(unix)]
 use std::path::Path;
+use std::sync::Arc;
 use tracing::subscriber::set_global_default;
 use tracing_log::LogTracer;
 use tracing_subscriber::fmt::MakeWriter;
@@ -28,6 +29,9 @@ use crate::devices::cpu::power::CpuPowerBroadcasts;
 use crate::devices::cpu::CpuManagementTasks;
 #[cfg(target_os = "linux")]
 use crate::devices::cpu::{CpuManager, RaplCpu};
+use crate::devices::gpu::command_override::GpuCommandOverrides;
+#[cfg(any(feature = "nvml", feature = "amdsmi"))]
+use crate::devices::gpu::command_override::OverriddenGpu;
 #[cfg(any(feature = "nvml", feature = "amdsmi"))]
 use crate::devices::gpu::power::start_gpu_poller;
 use crate::devices::gpu::power::GpuPowerBroadcasts;
@@ -251,6 +255,7 @@ pub fn resolve_gpu_backend(requested: GpuBackend) -> anyhow::Result<ResolvedGpuB
 #[cfg(any(feature = "nvml", feature = "amdsmi"))]
 fn start_gpu_device_tasks_for<T: StartupGpu>(
     backend_name: &str,
+    overrides: Option<Arc<GpuCommandOverrides>>,
 ) -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
     tracing::info!("Starting {} and GPU management tasks.", backend_name);
     let num_gpus = T::device_count()?;
@@ -278,18 +283,32 @@ fn start_gpu_device_tasks_for<T: StartupGpu>(
             },
         )
         .collect();
-    Ok((GpuManagementTasks::start(gpus)?, gpu_info))
+    let tasks = if let Some(overrides) = overrides {
+        let gpus = gpus
+            .into_iter()
+            .enumerate()
+            .map(|(gpu_id, gpu)| OverriddenGpu::new(gpu_id, gpu, overrides.clone()))
+            .collect();
+        GpuManagementTasks::start(gpus)?
+    } else {
+        GpuManagementTasks::start(gpus)?
+    };
+    Ok((tasks, gpu_info))
 }
 
 /// Initialize the resolved backend and start GPU management tasks.
 pub fn start_gpu_device_tasks(
     backend: ResolvedGpuBackend,
+    overrides: Option<Arc<GpuCommandOverrides>>,
 ) -> anyhow::Result<(GpuManagementTasks, Vec<GpuDiscoveryInfo>)> {
+    let _ = &overrides;
     match backend {
         #[cfg(feature = "nvml")]
-        ResolvedGpuBackend::Nvml => start_gpu_device_tasks_for::<NvmlGpu<'static>>("NVML"),
+        ResolvedGpuBackend::Nvml => {
+            start_gpu_device_tasks_for::<NvmlGpu<'static>>("NVML", overrides)
+        }
         #[cfg(feature = "amdsmi")]
-        ResolvedGpuBackend::Amdsmi => start_gpu_device_tasks_for::<AmdsmiGpu>("AMD SMI"),
+        ResolvedGpuBackend::Amdsmi => start_gpu_device_tasks_for::<AmdsmiGpu>("AMD SMI", overrides),
         ResolvedGpuBackend::None => Ok((GpuManagementTasks::empty(), Vec::new())),
     }
 }
@@ -377,7 +396,10 @@ pub fn start_cpu_power_poller(_poll_hz: u32) -> anyhow::Result<CpuPowerBroadcast
 /// Reject API groups that aren't supported on this platform or that the
 /// daemon lacks the privileges for.
 #[allow(unused_variables)]
-pub fn check_privileges(enabled_groups: &[ApiGroup]) -> anyhow::Result<()> {
+pub fn check_privileges(
+    enabled_groups: &[ApiGroup],
+    overrides: Option<&GpuCommandOverrides>,
+) -> anyhow::Result<()> {
     #[cfg(all(
         not(target_os = "linux"),
         not(any(feature = "nvml", feature = "amdsmi"))
@@ -421,6 +443,23 @@ pub fn check_privileges(enabled_groups: &[ApiGroup]) -> anyhow::Result<()> {
         let is_root = nix::unistd::geteuid().is_root();
         for &group in enabled_groups {
             if group.requires_root() && !is_root {
+                if group == ApiGroup::GpuControl && overrides.is_some_and(|value| !value.is_empty())
+                {
+                    let operation_names = overrides
+                        .expect("nonempty overrides were checked")
+                        .overridden_operation_names()
+                        .join(", ");
+                    tracing::info!(
+                        "API group 'gpu-control' is enabled without root because command overrides \
+                         are configured for: {}",
+                        operation_names,
+                    );
+                    tracing::warn!(
+                        "GPU control operations without a command override will use the native \
+                         driver path and may fail with permission errors."
+                    );
+                    continue;
+                }
                 tracing::error!(
                     "API group '{}' requires root privileges. \
                      Either run as root or remove it from --enable.",
@@ -714,7 +753,19 @@ mod tests {
         assert!(fs::metadata(path).is_ok());
 
         // The socket file is left behind, but no one is listening on it.
-        get_unix_listener(path, 0o666, None, None).unwrap();
+        // Other tests in this binary spawn subprocesses, and between a
+        // concurrent fork and exec the child holds a duplicate of the dropped
+        // listener's file descriptor, briefly making the socket look live.
+        // Retry to ride out that window.
+        let mut result = get_unix_listener(path, 0o666, None, None);
+        for _ in 0..10 {
+            if result.is_ok() {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+            result = get_unix_listener(path, 0o666, None, None);
+        }
+        result.unwrap();
     }
 
     #[test]


### PR DESCRIPTION
In some clusters, specific scripts are available with passwordless sudo to enable GPU power capping or frequency setting. This intends to support that cluster configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable GPU command overrides using TOML files.
  * Supports placeholders, sequential execution, timeouts, output-based error detection, and detailed failure reporting.
  * Enables non-root GPU control when applicable operations are overridden.
* **Documentation**
  * Added comprehensive HTTP API reference documentation.
  * Added setup and configuration guidance for GPU command overrides.
  * Reorganized daemon documentation into overview, API, and command override pages.
* **Bug Fixes**
  * Improved stale-socket startup handling.
  * Unconfigured GPU operations continue using native driver behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->