### PR TITLE
Assume single-process execution when no DL framework is available

### DIFF
--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -141,10 +141,7 @@ def all_reduce(object: list[int] | list[float], operation: Literal["sum", "max"]
         tensor = torch.Tensor(object).cuda()
 
         # determine operation
-        if operation == "sum":
-            torch_op = torch.distributed.ReduceOp.SUM
-        else:
-            torch_op = torch.distributed.ReduceOp.MAX
+        torch_op = torch.distributed.ReduceOp.SUM if operation == "sum" else torch.distributed.ReduceOp.MAX
 
         torch.distributed.all_reduce(tensor, op=torch_op)
         return tensor.cpu().tolist()

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -158,7 +158,7 @@ def all_reduce(object: list[int] | list[float], operation: Literal["sum", "max"]
         # TODO: Implement JAX distributed all-reduce logic.
         raise NotImplementedError("JAX distributed is not supported yet.")
 
-    raise RuntimeError("No framework is available.")
+    return object
 
 
 def is_distributed() -> bool:
@@ -169,7 +169,7 @@ def is_distributed() -> bool:
     if jax_is_available():
         jax = MODULE_CACHE["jax"]
         return jax.device_count() > 1
-    raise RuntimeError("No framework is available.")
+    return False
 
 
 def get_rank() -> int:

--- a/zeus/utils/framework.py
+++ b/zeus/utils/framework.py
@@ -127,6 +127,9 @@ def all_reduce(object: list[int] | list[float], operation: Literal["sum", "max"]
 
     If the current execution is not distributed, the object is returned as is.
     """
+    if operation not in ["sum", "max"]:
+        raise ValueError(f"all_reduce unsupported operation: {operation}")
+
     if torch_is_available(ensure_cuda=False):
         torch = MODULE_CACHE["torch"]
 
@@ -140,10 +143,8 @@ def all_reduce(object: list[int] | list[float], operation: Literal["sum", "max"]
         # determine operation
         if operation == "sum":
             torch_op = torch.distributed.ReduceOp.SUM
-        elif operation == "max":
-            torch_op = torch.distributed.ReduceOp.MAX
         else:
-            raise ValueError(f"all_reduce unsupported operation: {operation}")
+            torch_op = torch.distributed.ReduceOp.MAX
 
         torch.distributed.all_reduce(tensor, op=torch_op)
         return tensor.cpu().tolist()


### PR DESCRIPTION
`get_rank` and `get_world_size` fall back to `0` and `1` when neither PyTorch nor JAX is importable, and `all_reduce`'s docstring says "If the current execution is not distributed, the object is returned as is" — but `is_distributed` and `all_reduce` raise `RuntimeError("No framework is available.")` instead. This makes the two consistent with the rest of the module.

The visible effect is that `GlobalPowerLimitOptimizer.__init__` no longer raises without a DL framework installed. That alone doesn't make power limiting framework-free, though: `ZeusMonitor` still synchronizes with PyTorch by default.

`sync_execution` is left raising on purpose — silently skipping synchronization would produce measurement windows that don't bound the measured computation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior when no supported framework is available.
  * Supported reduction operations now safely return the original input when framework support is unavailable.
  * Distributed processing checks now correctly indicate when it is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->