### PR TITLE
Fix `infer_counter_update_period` always returning zero

### DIFF
--- a/tests/monitor/test_power.py
+++ b/tests/monitor/test_power.py
@@ -1,0 +1,30 @@
+"""Tests for GPU power counter update period inference."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from zeus.monitor.power import infer_counter_update_period
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_infers_half_the_fastest_counter_period(mocker: MockerFixture) -> None:
+    """The fastest probed counter period is halved and returned.
+
+    Regression test for the accumulator being seeded with `0.0` and folded with
+    `min`, which pinned the result at `0.0` for every input.
+    """
+    gpus = mocker.MagicMock()
+    gpus.get_name.side_effect = lambda index: ["A40", "V100"][index]
+    mocker.patch("zeus.monitor.power.get_gpus", return_value=gpus)
+    mocker.patch(
+        "zeus.monitor.power._infer_counter_update_period_single",
+        side_effect=lambda index: [0.4, 0.12][index],
+    )
+
+    # 0.12 s is the fastest counter, so poll twice per update at 0.06 s.
+    assert infer_counter_update_period([0, 1]) == pytest.approx(0.06)

--- a/tests/monitor/test_power.py
+++ b/tests/monitor/test_power.py
@@ -1,4 +1,4 @@
-"""Tests for GPU power counter update period inference."""
+"""Tests for the power monitor."""
 
 from __future__ import annotations
 

--- a/zeus/monitor/power.py
+++ b/zeus/monitor/power.py
@@ -38,7 +38,7 @@ def infer_counter_update_period(gpu_indicies: list[int]) -> float:
     gpus = get_gpus()
 
     # For each unique GPU model, infer the update period.
-    update_period = 0.0
+    update_period = float("inf")
     gpu_models_covered = set()
     for index in gpu_indicies:
         if (model := gpus.get_name(index)) not in gpu_models_covered:


### PR DESCRIPTION
# Fix `infer_counter_update_period` always returning zero

`infer_counter_update_period` returns `0.0` for every input:

```python
update_period = 0.0
...
    update_period = min(update_period, detected_period)
```

`min` never increases, and every period the probe returns is positive, so the seed wins every comparison. The halving then keeps it at `0.0` and `0.0 > 0.1` is false, so the clamp never fires either — the per-model probing, including the 1000-sample calibration loop, runs at startup and has its result discarded.

That `0.0` becomes `PowerMonitor.update_period`, where the polling processes compute `sleep_time = update_period - elapsed`. It is never positive, so they never sleep and poll the power backend as fast as it answers. This is the path taken whenever `update_period` is unset — `ZeusMonitor` on GPUs without a usable energy counter, and `PowerGauge` in `zeus/metric.py` on any GPU.

## Fix

```diff
-    update_period = 0.0
+    update_period = float("inf")
```

`inf` is the identity element of `min`, so the seed stops competing with the probed values. A finite seed would not do: `0.1`, for instance, still wins against every counter slower than 0.1 s and would cap the result at `0.05`.

With the probe stubbed, a 0.4 s and a 0.12 s counter now give `0.06` instead of `0.0`. The halving and clamp are unchanged; they are just reachable for the first time.

Introduced in `2dbd5a6`; `c79c631` later rewrote the branch into `min(...)` and preserved the defect.

## Test

Adds `tests/monitor/test_power.py` with one regression test that stubs the GPU manager and the probe, so it needs no GPU. It fails against `master` with `assert 0.0 == 0.06`.

## Notes

- With an empty GPU list the function now returns `0.1` via the clamp, but logs `Inferred update period (inf s) is too long`. Cosmetic, and unreachable through `PowerMonitor`, which rejects empty GPU sets. Happy to add an early return.
- Now that polling actually sleeps, a window shorter than the polling period can read as zero energy; `approx_instant_energy` covers this and already warns. Docs note to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU power counter update-period detection to correctly use the fastest detected counter period.
  * Ensured update intervals are calculated accurately across systems with multiple GPUs.

* **Tests**
  * Added regression coverage for GPU counter update-period calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->