### PR TITLE
[Docs] `zeus-ml` -> `zeus` typo fix

### DIFF
--- a/examples/prometheus/README.md
+++ b/examples/prometheus/README.md
@@ -19,7 +19,7 @@ You just need to download and extract the ImageNet data and mount it to the Dock
     ```
 1. Install `prometheus_client`:
     ```sh
-    pip install zeus-ml[prometheus]
+    pip install zeus[prometheus]
     ```
 
 ## EnergyHistogram, PowerGauge, and EnergyCumulativeCounter


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Prometheus client installation instructions to use the current `zeus[prometheus]` package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->