### PR TITLE
Add zeus.device.machine with a Raspberry Pi 5 PMIC backend

### DIFF
--- a/docs/measure/index.md
+++ b/docs/measure/index.md
@@ -183,7 +183,7 @@ DRAM energy measurement are available on some CPUs as well.
 
 To check CPU/GPU/DRAM measurement support, refer to [Verifying installation](../getting_started/index.md#verifying-installation).
 
-Energy measurement for Apple Silicon and Jetson Platforms is supported as well. For more information, refer to [Apple Silicon](#apple-silicon) and [Jetson Platforms](#jetson-platforms).
+Energy measurement for Apple Silicon and Jetson Platforms is supported as well. For more information, refer to [Apple Silicon](#apple-silicon) and [Jetson Platforms](#jetson-platforms). Whole-machine power is supported on the Raspberry Pi 5; see [Whole-machine power](#whole-machine-power).
 
 ### Generic device interfaces
 
@@ -193,7 +193,35 @@ These [`GPU`][zeus.device.gpu.common.GPU] objects directly call respective `nvml
 - [`NVIDIAGPU.get_name`][zeus.device.gpu.nvidia.NVIDIAGPU.get_name] calls `pynvml.nvmlDeviceGetName`.
 - [`AMDGPU.get_name`][zeus.device.gpu.amd.AMDGPU.get_name] calls `amdsmi.amdsmi_get_gpu_asic_info`.
 
-[`get_cpus`][zeus.device.get_cpus] is similar to [`get_gpus`][zeus.device.get_gpus], but rather abstracts over CPU vendors; [`get_soc`][zeus.device.get_soc] abstracts over SoC platforms (currently Apple Silicon and Jetson).
+[`get_cpus`][zeus.device.get_cpus] is similar to [`get_gpus`][zeus.device.get_gpus], but rather abstracts over CPU vendors; [`get_soc`][zeus.device.get_soc] abstracts over SoC platforms (currently Apple Silicon and Jetson); [`get_machine`][zeus.device.machine.get_machine] abstracts over whole-machine power meters (currently the Raspberry Pi 5).
+
+### Whole-machine power
+
+A machine meter sits off the die: a PMIC metering board rails, a BMC answering over IPMI, a wall meter. That is the distinction from [`get_soc`][zeus.device.get_soc], whose sensors are on the processor and so can only ever account for part of what the box draws.
+
+Every implementation reports `machine_energy_mj`, because whole-machine energy is the one figure any of these sources can give. Domains finer than that are added by the platform's own measurement class, so a board whose PMIC breaks out a DRAM rail can report it while a BMC that only knows the chassis total does not have to pretend otherwise.
+
+#### Raspberry Pi
+
+The Pi 5 is the first Pi whose PMIC exposes per-rail current and voltage to userspace. Twelve rails carry both channels on a Model B Rev 1.0; `EXT5V` and `BATT` report a voltage and no current, so they cannot yield power and are skipped. Earlier Pi models do not expose the ADC at all.
+
+[`RPIMeasurement`][zeus.device.machine.rpi.RPIMeasurement] carries `machine_energy_mj` summed over all twelve rails, plus `cpu_energy_mj` from the SoC core rail and `dram_energy_mj` from the two DRAM rails. The machine figure is board-level, so it includes the wireless, HDMI and I/O rails and is larger than the sum of the other two. Reporting them separately is what lets you tell compute-bound work from memory-bound work: measured on a Pi 5, a four-core memcpy moves the DRAM rails about 96 times harder relative to the core rail than a four-core register spin does.
+
+```python
+from zeus.device.machine import get_machine
+
+machine = get_machine()
+machine.begin_window("inference")
+# ... run something ...
+measurement = machine.end_window("inference")
+print(measurement.machine_energy_mj, measurement.cpu_energy_mj, measurement.dram_energy_mj)
+```
+
+The PMIC has no cumulative energy counter, so Zeus samples power and integrates it trapezoidally, at 10 Hz by default. Each sample costs roughly 23 ms of firmware ADC time, almost all of it inside the firmware rather than in the caller, so a faster poll takes measurable CPU away from the workload being measured. Pass `poll_interval_s` if you need a different rate.
+
+Sampling goes through the firmware mailbox on a descriptor opened once, rather than spawning `vcgencmd` per reading. `/dev/vcio` is `root:video` mode 0660, so membership of the `video` group is enough and no root is required, unlike Intel RAPL. Where the device is not reachable, for example inside a container that does not map it, Zeus falls back to `vcgencmd` automatically.
+
+Both DRAM rails are read. At idle both report exact zero in almost every sample, which is a property of the ADC at low current rather than of the rails; under load `DDR_VDD2` and `DDR_VDDQ` are both populated, with `VDDQ` carrying roughly 14% of DRAM power. A low sampling rate will therefore underestimate DRAM energy on a lightly loaded board.
 
 ### AMD GPU
 

--- a/tests/device/machine/test_rpi.py
+++ b/tests/device/machine/test_rpi.py
@@ -1,0 +1,248 @@
+"""Tests for the Raspberry Pi 5 PMIC machine backend.
+
+None of these need a Pi. The parser runs against captured `pmic_read_adc`
+output, and the monitor is driven through a fake `PMICReader` so the integration
+and windowing logic can be checked deterministically.
+"""
+
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from zeus.device.machine.common import EmptyMachine, MachineMeasurement
+from zeus.device.machine.rpi import (
+    PMICReadError,
+    PMICReader,
+    RaspberryPi,
+    RPIMeasurement,
+    VcgencmdPMICReader,
+    ZeusRaspberryPiInitError,
+    _accumulate,
+    default_reader,
+    rpi_is_available,
+)
+
+# Captured verbatim from `vcgencmd pmic_read_adc` on a Raspberry Pi 5 Model B
+# Rev 1.0 (2 GB), Raspberry Pi OS bookworm, with four busy cores. Under load
+# both DRAM rails carry current: DDR_VDD2 at 0.225 A and DDR_VDDQ at 0.067 A.
+# At idle both read exact zero, which is a property of the ADC at low current,
+# so an idle capture would wrongly suggest DDR_VDDQ is never populated.
+PMIC_OUTPUT = """ 3V7_WL_SW_A current(0)=0.09368929A
+   3V3_SYS_A current(1)=0.08783370A
+   1V8_SYS_A current(2)=0.18054710A
+  DDR_VDD2_A current(3)=0.22543980A
+  DDR_VDDQ_A current(4)=0.06666720A
+   1V1_SYS_A current(5)=0.17566740A
+    0V8_SW_A current(6)=0.37670900A
+  VDD_CORE_A current(7)=6.22421000A
+   3V3_DAC_A current(17)=0.00006105A
+   3V3_ADC_A current(18)=0.00036630A
+   0V8_AON_A current(16)=0.00305250A
+      HDMI_A current(22)=0.02417580A
+ 3V7_WL_SW_V volt(8)=3.69977600V
+   3V3_SYS_V volt(9)=3.31003300V
+   1V8_SYS_V volt(10)=1.80512600V
+  DDR_VDD2_V volt(11)=1.10476100V
+  DDR_VDDQ_V volt(12)=0.60146460V
+   1V1_SYS_V volt(13)=1.11025500V
+    0V8_SW_V volt(14)=0.80146440V
+  VDD_CORE_V volt(15)=0.86173300V
+   3V3_DAC_V volt(20)=3.31318300V
+   3V3_ADC_V volt(21)=3.30677300V
+   0V8_AON_V volt(19)=0.80029220V
+      HDMI_V volt(23)=5.08664000V
+     EXT5V_V volt(24)=5.09066000V
+      BATT_V volt(25)=0.00000000V
+"""
+
+
+class FakePMICReader(PMICReader):
+    """Returns a scripted sequence of per-rail power readings, in mW."""
+
+    def __init__(self, samples, fail_after=None):
+        self.samples = list(samples)
+        self.calls = 0
+        self.fail_after = fail_after
+        self.closed = False
+
+    def read_rail_power_mw(self):
+        self.calls += 1
+        if self.fail_after is not None and self.calls > self.fail_after:
+            raise PMICReadError("scripted failure")
+        return dict(self.samples[min(self.calls - 1, len(self.samples) - 1)])
+
+    def close(self):
+        self.closed = True
+
+
+class TestParsing:
+    def test_only_rails_with_both_channels_yield_power(self):
+        rails = PMICReader.parse(PMIC_OUTPUT)
+        assert len(rails) == 12
+        # Voltage-only channels cannot give power and must not appear.
+        assert "EXT5V" not in rails
+        assert "BATT" not in rails
+
+    def test_power_is_current_times_voltage_in_mw(self):
+        rails = PMICReader.parse(PMIC_OUTPUT)
+        assert rails["VDD_CORE"] == pytest.approx(6.22421 * 0.861733 * 1000.0)
+
+    def test_both_dram_rails_carry_current_under_load(self):
+        # The idle capture this fixture replaced showed DDR_VDDQ at 0 A, which
+        # invited the conclusion that it is never populated. It is.
+        rails = PMICReader.parse(PMIC_OUTPUT)
+        assert rails["DDR_VDD2"] > 0.0
+        assert rails["DDR_VDDQ"] > 0.0
+
+    def test_garbage_lines_are_ignored(self):
+        assert PMICReader.parse("not an adc line\n\n") == {}
+
+    def test_nul_separated_output_parses(self):
+        # The mailbox returns one NUL-separated blob rather than newlines.
+        blob = PMIC_OUTPUT.replace("\n", "\x00")
+        assert len(PMICReader.parse(blob)) == 12
+
+
+class TestMeasurement:
+    def test_machine_energy_is_required_and_domains_are_not(self):
+        m = RPIMeasurement(machine_energy_mj=5.0)
+        assert m.machine_energy_mj == 5.0
+        assert m.cpu_energy_mj is None
+        assert m.dram_energy_mj is None
+
+    def test_is_a_machine_measurement(self):
+        assert isinstance(RPIMeasurement(machine_energy_mj=0.0), MachineMeasurement)
+
+    def test_subtraction_is_field_wise(self):
+        later = RPIMeasurement(machine_energy_mj=10.0, cpu_energy_mj=6.0, dram_energy_mj=1.0)
+        earlier = RPIMeasurement(machine_energy_mj=4.0, cpu_energy_mj=2.0, dram_energy_mj=0.5)
+        diff = later - earlier
+        assert diff.machine_energy_mj == 6.0
+        assert diff.cpu_energy_mj == 4.0
+        assert diff.dram_energy_mj == 0.5
+
+    def test_a_domain_unreadable_on_either_side_stays_none(self):
+        later = RPIMeasurement(machine_energy_mj=10.0, cpu_energy_mj=6.0)
+        earlier = RPIMeasurement(machine_energy_mj=4.0, cpu_energy_mj=2.0)
+        assert (later - earlier).dram_energy_mj is None
+
+    def test_subtracting_a_different_type_is_refused(self):
+        with pytest.raises(TypeError):
+            RPIMeasurement(machine_energy_mj=1.0) - object()  # type: ignore[operator]
+
+    def test_zero_all_fields_leaves_unreadable_domains_alone(self):
+        m = RPIMeasurement(machine_energy_mj=9.0, cpu_energy_mj=3.0)
+        m.zero_all_fields()
+        assert m.machine_energy_mj == 0.0
+        assert m.cpu_energy_mj == 0.0
+        assert m.dram_energy_mj is None
+
+
+class TestAccumulate:
+    def test_trapezoidal_over_one_interval(self):
+        cumulative = RPIMeasurement(machine_energy_mj=0.0, cpu_energy_mj=0.0, dram_energy_mj=0.0)
+        prev = {"VDD_CORE": 1000.0, "DDR_VDD2": 100.0}
+        now = {"VDD_CORE": 3000.0, "DDR_VDD2": 300.0}
+        _accumulate(cumulative, prev, now, 2.0)
+        # mean power times dt, per rail
+        assert cumulative.cpu_energy_mj == pytest.approx(2000.0 * 2.0)
+        assert cumulative.dram_energy_mj == pytest.approx(200.0 * 2.0)
+        assert cumulative.machine_energy_mj == pytest.approx(2000.0 * 2.0 + 200.0 * 2.0)
+
+    def test_machine_total_covers_rails_outside_the_named_domains(self):
+        cumulative = RPIMeasurement(machine_energy_mj=0.0)
+        prev = {"VDD_CORE": 1000.0, "HDMI": 100.0}
+        now = {"VDD_CORE": 1000.0, "HDMI": 100.0}
+        _accumulate(cumulative, prev, now, 1.0)
+        assert cumulative.machine_energy_mj == pytest.approx(1100.0)
+
+    def test_a_rail_missing_from_one_sample_is_skipped(self):
+        cumulative = RPIMeasurement(machine_energy_mj=0.0, dram_energy_mj=None)
+        _accumulate(cumulative, {"VDD_CORE": 1000.0}, {}, 1.0)
+        assert cumulative.machine_energy_mj == 0.0
+
+
+class TestMonitor:
+    def _monitor(self, reader):
+        return RaspberryPi(reader=reader, poll_interval_s=0.01)
+
+    def test_init_refuses_a_board_with_no_usable_rail(self):
+        with pytest.raises(ZeusRaspberryPiInitError, match="no rail"):
+            self._monitor(FakePMICReader([{}]))
+
+    def test_init_surfaces_a_read_failure(self):
+        with pytest.raises(ZeusRaspberryPiInitError, match="scripted failure"):
+            self._monitor(FakePMICReader([{"VDD_CORE": 1.0}], fail_after=0))
+
+    def test_windows_return_a_difference(self):
+        reader = FakePMICReader([{"VDD_CORE": 1000.0, "DDR_VDD2": 100.0}])
+        mon = self._monitor(reader)
+        try:
+            mon.begin_window("w")
+            result = mon.end_window("w")
+            assert isinstance(result, RPIMeasurement)
+            assert result.machine_energy_mj >= 0.0
+        finally:
+            mon._stop_process()
+
+    def test_duplicate_window_is_refused_unless_restarted(self):
+        mon = self._monitor(FakePMICReader([{"VDD_CORE": 1000.0}]))
+        try:
+            mon.begin_window("w")
+            with pytest.raises(KeyError):
+                mon.begin_window("w")
+            mon.begin_window("w", restart=True)
+        finally:
+            mon._stop_process()
+
+    def test_unknown_window_is_refused(self):
+        mon = self._monitor(FakePMICReader([{"VDD_CORE": 1000.0}]))
+        try:
+            with pytest.raises(KeyError):
+                mon.end_window("never opened")
+        finally:
+            mon._stop_process()
+
+
+class TestAvailability:
+    def test_not_available_off_linux(self):
+        with patch.object(sys, "platform", "darwin"):
+            assert rpi_is_available() is False
+
+    def test_not_available_on_x86(self):
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch("zeus.device.machine.rpi.platform.machine", return_value="x86_64"),
+        ):
+            assert rpi_is_available() is False
+
+    def test_not_available_without_a_pi_model_string(self):
+        with (
+            patch.object(sys, "platform", "linux"),
+            patch("zeus.device.machine.rpi.platform.machine", return_value="aarch64"),
+            patch("zeus.device.machine.rpi.Path.read_bytes", return_value=b"Some Other Board"),
+        ):
+            assert rpi_is_available() is False
+
+
+class TestReaderSelection:
+    def test_falls_back_to_vcgencmd_when_the_mailbox_is_unusable(self):
+        with patch(
+            "zeus.device.machine.rpi.VcioPMICReader",
+            side_effect=PMICReadError("no /dev/vcio"),
+        ):
+            assert isinstance(default_reader(), VcgencmdPMICReader)
+
+
+class TestEmptyMachine:
+    def test_every_operation_refuses(self):
+        empty = EmptyMachine()
+        assert empty.get_available_metrics() == set()
+        for call in (
+            empty.get_total_energy_consumption,
+            lambda: empty.begin_window("w"),
+            lambda: empty.end_window("w"),
+        ):
+            with pytest.raises(ValueError, match="No machine power meter"):
+                call()

--- a/zeus/device/exception.py
+++ b/zeus/device/exception.py
@@ -27,6 +27,14 @@ class ZeusBaseSoCError(ZeusBaseError):
         super().__init__(message)
 
 
+class ZeusBaseMachineError(ZeusBaseError):
+    """Zeus base machine exception class."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Base Zeus Exception."""
+        super().__init__(message)
+
+
 class ZeusdError(ZeusBaseGPUError):
     """Exception class for Zeus daemon-related errors."""
 

--- a/zeus/device/machine/__init__.py
+++ b/zeus/device/machine/__init__.py
@@ -1,0 +1,64 @@
+"""Abstraction layer for whole-machine power meters.
+
+The main function of this module is [`get_machine`][zeus.device.machine.get_machine],
+which returns a machine manager object specific to the platform.
+
+A machine meter sits off the die: a PMIC metering board rails, a BMC answering
+over IPMI, a wall meter. That is the distinction from
+[`zeus.device.soc`][zeus.device.soc], whose sensors live on the processor and so
+can only ever account for part of the machine's draw.
+"""
+
+from __future__ import annotations
+
+from contextlib import suppress
+
+from zeus.device.machine.common import (
+    EmptyMachine,
+    Machine,
+    MachineMeasurement,
+    ZeusMachineInitError,
+)
+from zeus.device.machine.rpi import (
+    RaspberryPi,
+    RPIMeasurement,
+    ZeusRaspberryPiInitError,
+    rpi_is_available,
+)
+
+__all__ = [
+    "EmptyMachine",
+    "Machine",
+    "MachineMeasurement",
+    "RPIMeasurement",
+    "RaspberryPi",
+    "ZeusMachineInitError",
+    "ZeusRaspberryPiInitError",
+    "get_machine",
+    "rpi_is_available",
+]
+
+_machine: Machine | None = None
+
+
+def get_machine() -> Machine:
+    """Initialize and return a singleton machine power meter.
+
+    Currently supported:
+        - Raspberry Pi 5
+
+    Raises:
+        ZeusMachineInitError: No machine-level meter could be initialized.
+    """
+    global _machine
+    if _machine is not None:
+        return _machine
+
+    if rpi_is_available():
+        with suppress(ZeusRaspberryPiInitError):
+            _machine = RaspberryPi()
+
+    # For additional machines, add more initialization attempts.
+    if _machine is None:
+        raise ZeusMachineInitError("No machine-level power meter is available on this host.")
+    return _machine

--- a/zeus/device/machine/common.py
+++ b/zeus/device/machine/common.py
@@ -1,0 +1,122 @@
+"""Error wrappers and classes common to all whole-machine power meters.
+
+A machine here is the box rather than the chip. The meter is off-die: a PMIC
+metering board rails, a BMC answering over IPMI, a wall meter. That is the
+difference from `zeus.device.soc`, whose sensors are on the processor itself and
+so can only ever see part of the draw.
+
+Every implementation must be able to report whole-machine energy, because that
+is the one figure any of these sources can give. Anything finer is up to the
+derived measurement class, since a PMIC that breaks out a DRAM rail and a BMC
+that reports one number for the chassis have very little in common below that.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, fields
+from typing import TypeVar
+
+from zeus.device.exception import ZeusBaseMachineError
+
+# So that subtracting two measurements of a concrete type gives that type back
+# rather than the base, which a caller reaching for a platform-specific field needs.
+TMachineMeasurement = TypeVar("TMachineMeasurement", bound="MachineMeasurement")
+
+
+class ZeusMachineInitError(ZeusBaseMachineError):
+    """Import error or machine metering initialization failures."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize the exception object."""
+        super().__init__(message)
+
+
+@dataclass
+class MachineMeasurement(abc.ABC):
+    """Energy consumed by a whole machine, and by whichever domains it can separate.
+
+    `machine_energy_mj` is the only field guaranteed to be present. Derived
+    classes add the domains their hardware can actually distinguish, for example
+    a CPU rail and a DRAM rail on a board whose PMIC meters them separately.
+    Refer to the derived class for a specific platform, or print an instance.
+
+    Units: mJ
+    """
+
+    machine_energy_mj: float
+
+    def __sub__(self: TMachineMeasurement, other: TMachineMeasurement) -> TMachineMeasurement:
+        """Return a measurement holding the difference across every field.
+
+        Fields that are None on either side stay None, because a domain that
+        was unreadable for part of a window has no meaningful delta.
+        """
+        if type(self) is not type(other):
+            raise TypeError(f"cannot subtract {type(other).__name__} from {type(self).__name__}")
+        diff = {}
+        for f in fields(self):
+            mine, theirs = getattr(self, f.name), getattr(other, f.name)
+            diff[f.name] = None if mine is None or theirs is None else mine - theirs
+        return type(self)(**diff)
+
+    def zero_all_fields(self) -> None:
+        """Set every field that carries a value to zero, leaving None fields alone."""
+        for f in fields(self):
+            if getattr(self, f.name) is not None:
+                setattr(self, f.name, 0.0)
+
+
+class Machine(abc.ABC):
+    """Abstract base class for metering the energy of a whole machine.
+
+    Used by ZeusMonitor in the same way as the SoC and CPU managers.
+    """
+
+    @abc.abstractmethod
+    def get_available_metrics(self) -> set[str]:
+        """Return the set of measurement fields this machine actually populates."""
+
+    @abc.abstractmethod
+    def get_total_energy_consumption(self) -> MachineMeasurement:
+        """Return cumulative energy since a fixed arbitrary point.
+
+        Successive calls over the lifetime of one manager object count from the
+        same origin, so a caller can difference any two of them.
+
+        Units: mJ.
+        """
+
+    @abc.abstractmethod
+    def begin_window(self, key: str, restart: bool = False) -> None:
+        """Begin a measurement interval labeled with `key`.
+
+        Args:
+            key: Unique name of the measurement window.
+            restart: If True and the window already exists, cancel the existing
+                window and start a new one.
+        """
+
+    @abc.abstractmethod
+    def end_window(self, key: str) -> MachineMeasurement:
+        """End a measurement window and return the energy consumed. Units: mJ."""
+
+
+class EmptyMachine(Machine):
+    """Stand-in used when no machine-level meter is available."""
+
+    def get_available_metrics(self) -> set[str]:
+        """Return an empty set, since nothing is measurable."""
+        return set()
+
+    def get_total_energy_consumption(self) -> MachineMeasurement:
+        """Raise, since nothing is measurable."""
+        raise ValueError("No machine power meter is available.")
+
+    def begin_window(self, key: str, restart: bool = False) -> None:
+        """Raise, since nothing is measurable."""
+        raise ValueError("No machine power meter is available.")
+
+    def end_window(self, key: str) -> MachineMeasurement:
+        """Raise, since nothing is measurable."""
+        raise ValueError("No machine power meter is available.")

--- a/zeus/device/machine/rpi.py
+++ b/zeus/device/machine/rpi.py
@@ -1,0 +1,483 @@
+"""Raspberry Pi 5 whole-machine power via the on-board PMIC.
+
+The Pi 5 is the first Pi whose PMIC exposes per-rail current and voltage to
+userspace. Twelve rails carry both channels on a Model B Rev 1.0, including the
+SoC core rail and the two DRAM rails, so the board can be metered as a whole and
+broken down at the same time. `EXT5V` and `BATT` report a voltage and no
+current, so they cannot yield power and are skipped.
+
+The PMIC is a separate chip metering board rails rather than an on-die sensor,
+which is why this lives under `machine` and not under `soc`.
+
+There is no cumulative energy counter in the hardware, so power is sampled and
+integrated here, the same shape the Jetson SoC backend uses.
+"""
+
+from __future__ import annotations
+
+import abc
+import array
+import asyncio
+import atexit
+import contextlib
+import enum
+import multiprocessing as mp
+import os
+import platform
+import re
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from queue import Empty
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - the mailbox is a Linux device
+    fcntl = None  # ty: ignore[invalid-assignment]
+
+from zeus.device.machine.common import (
+    Machine,
+    MachineMeasurement,
+    ZeusMachineInitError,
+)
+
+# `vcgencmd pmic_read_adc` prints one line per ADC channel, e.g.
+#
+#      VDD_CORE_A current(7)=0.81262990A
+#      VDD_CORE_V volt(15)=0.86065850V
+#        EXT5V_V volt(24)=5.07860000V
+#
+# Channels ending in `_A` carry current and channels ending in `_V` carry
+# voltage; the shared prefix is the rail name.
+_ADC_LINE = re.compile(r"^\s*(?P<rail>\S+?)_(?P<kind>[AV])\s+(?:current|volt)\(\d+\)=(?P<value>[\d.]+)[AV]\s*$")
+
+_CPU_RAILS = ("VDD_CORE",)
+
+# Both DRAM rails are read. Characterised on a Pi 5 Model B Rev 1.0 at about
+# 50 Hz, 150 samples per condition: under a decode workload DDR_VDD2 is non-zero
+# in 148 of 150 samples (mean 0.212 W) and DDR_VDDQ in 135 of 150 (mean
+# 0.034 W), so VDDQ carries roughly 14% of DRAM power rather than nothing. At
+# idle both read exact zero in essentially every sample, which is a property of
+# the ADC at low current rather than of the rail, and it means a low-rate
+# sampler will underestimate DRAM energy on a lightly loaded board.
+_DRAM_RAILS = ("DDR_VDD2", "DDR_VDDQ")
+
+# 10 Hz. Sampling costs about 23 ms of firmware ADC time per read on this board,
+# almost all of it inside the firmware rather than in the caller, so a faster
+# poll takes measurable CPU away from the workload being measured.
+_DEFAULT_POLL_INTERVAL_S = 0.1
+
+_VCIO = "/dev/vcio"
+_IOCTL_MBOX_PROPERTY = 0xC0086400  # _IOWR(100, 0, 8)
+_TAG_VCGENCMD_STRING = 0x00030080
+_PAYLOAD_OFFSET = 24  # bytes; header is six 32-bit words
+_BUFBYTES = 1024
+
+
+class ZeusRaspberryPiInitError(ZeusMachineInitError):
+    """Raspberry Pi initialization failures."""
+
+    def __init__(self, message: str) -> None:
+        """Initialize Zeus Exception."""
+        super().__init__(message)
+
+
+class PMICReadError(RuntimeError):
+    """Raised when the PMIC ADC cannot be read."""
+
+
+class PMICReader(abc.ABC):
+    """Reads instantaneous per-rail power from the board's PMIC."""
+
+    @abc.abstractmethod
+    def read_rail_power_mw(self) -> dict[str, float]:
+        """Return a mapping of rail name to instantaneous power in mW."""
+
+    @abc.abstractmethod
+    def close(self) -> None:
+        """Release any resources held. Readers that hold none may do nothing."""
+
+    @staticmethod
+    def parse(output: str) -> dict[str, float]:
+        """Parse `pmic_read_adc` output into a rail name to power (mW) mapping."""
+        amps: dict[str, float] = {}
+        volts: dict[str, float] = {}
+        for line in output.replace("\x00", "\n").splitlines():
+            match = _ADC_LINE.match(line)
+            if match is None:
+                continue
+            rail = match.group("rail")
+            value = float(match.group("value"))
+            if match.group("kind") == "A":
+                amps[rail] = value
+            else:
+                volts[rail] = value
+
+        # Only rails carrying both channels yield power.
+        return {rail: amps[rail] * volts[rail] * 1000.0 for rail in amps.keys() & volts.keys()}
+
+
+class VcioPMICReader(PMICReader):
+    """Reads the PMIC through the firmware mailbox on a persistent descriptor.
+
+    `vcgencmd pmic_read_adc` does two things, which strace confirms: it opens
+    `/dev/vcio` and issues one `_IOWR(100, 0, 8)` mailbox property ioctl carrying
+    the command string under firmware tag 0x00030080. Doing that directly avoids
+    a process spawn per sample.
+
+    Worth being honest about the size of the win. Measured over 50 reads on a
+    Pi 5, this costs 22.6 ms per sample against 23.9 ms for the subprocess, so it
+    saves about 5%. The firmware's own ADC sweep dominates, and no userspace
+    change touches that. The reason to prefer it is that it does not fork a
+    process into the middle of the workload being measured, not that it is fast.
+
+    `/dev/vcio` is root:video mode 0660, so membership of the video group is
+    enough and no root is required.
+    """
+
+    def __init__(self, path: str = _VCIO) -> None:
+        """Open the mailbox device."""
+        try:
+            self._fd: int | None = os.open(path, os.O_RDONLY)
+        except OSError as exc:
+            raise PMICReadError(
+                f"Could not open {path}: {exc}. The mailbox device is root:video "
+                "mode 0660, so this usually means the user is not in the video group."
+            ) from exc
+        self.path = path
+
+    def close(self) -> None:
+        """Close the mailbox descriptor."""
+        if self._fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(self._fd)
+            self._fd = None
+
+    def __enter__(self) -> VcioPMICReader:
+        """Return self for use as a context manager."""
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Close the descriptor on exit."""
+        self.close()
+
+    def _command(self, command: str) -> str:
+        if fcntl is None:
+            raise PMICReadError("The firmware mailbox needs fcntl, which is Linux only.")
+        if self._fd is None:
+            raise PMICReadError("Mailbox descriptor is closed.")
+        words = _BUFBYTES // 4
+        buf = array.array("I", [0] * words)
+        buf[0] = _BUFBYTES
+        buf[1] = 0
+        buf[2] = _TAG_VCGENCMD_STRING
+        buf[3] = _BUFBYTES - _PAYLOAD_OFFSET
+        buf[4] = 0
+        raw = memoryview(buf).cast("B")
+        payload = command.encode() + b"\0"
+        raw[_PAYLOAD_OFFSET : _PAYLOAD_OFFSET + len(payload)] = payload
+        buf[words - 1] = 0
+
+        try:
+            # ty checks every platform (python-platform = "all"), and fcntl is
+            # Linux only. The None guard above covers the platforms it is missing on.
+            fcntl.ioctl(self._fd, _IOCTL_MBOX_PROPERTY, buf, True)  # ty: ignore[possibly-missing-attribute]
+        except OSError as exc:
+            raise PMICReadError(f"Mailbox ioctl failed: {exc}") from exc
+        if buf[1] != 0x80000000:
+            raise PMICReadError(f"Mailbox returned status 0x{buf[1]:08x}")
+
+        blob = memoryview(buf).cast("B")[_PAYLOAD_OFFSET:].tobytes()
+        return blob.split(b"\x00\x00")[0].decode("utf-8", "replace")
+
+    def read_rail_power_mw(self) -> dict[str, float]:
+        """Return a mapping of rail name to instantaneous power in mW."""
+        text = self._command("pmic_read_adc")
+        # The firmware answers an unregistered command with a body that parses
+        # to nothing. Catching it here keeps a rejected command from looking
+        # like a board with no rails.
+        if "error_msg" in text:
+            raise PMICReadError(f"Firmware rejected pmic_read_adc: {text.strip()}")
+        return self.parse(text)
+
+
+class VcgencmdPMICReader(PMICReader):
+    """Reads the PMIC by running `vcgencmd pmic_read_adc`.
+
+    Kept as the fallback for hosts where `/dev/vcio` is not reachable, for
+    example inside a container that does not map the device.
+    """
+
+    def __init__(self, vcgencmd: str = "vcgencmd", timeout_s: float = 5.0) -> None:
+        """Initialize the reader with the path to `vcgencmd`."""
+        self.vcgencmd = vcgencmd
+        self.timeout_s = timeout_s
+
+    def _run(self) -> str:
+        try:
+            proc = subprocess.run(
+                [self.vcgencmd, "pmic_read_adc"],
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_s,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise PMICReadError(f"Could not run `{self.vcgencmd} pmic_read_adc`: {exc}") from exc
+        if proc.returncode != 0:
+            raise PMICReadError(f"`{self.vcgencmd} pmic_read_adc` exited {proc.returncode}: {proc.stderr.strip()}")
+        return proc.stdout
+
+    def read_rail_power_mw(self) -> dict[str, float]:
+        """Return a mapping of rail name to instantaneous power in mW."""
+        return self.parse(self._run())
+
+    def close(self) -> None:
+        """No resources are held between reads."""
+
+
+def default_reader() -> PMICReader:
+    """Return the mailbox reader when it is usable, otherwise the subprocess one."""
+    try:
+        reader = VcioPMICReader()
+    except PMICReadError:
+        return VcgencmdPMICReader()
+    try:
+        if reader.read_rail_power_mw():
+            return reader
+    except PMICReadError:
+        pass
+    reader.close()
+    return VcgencmdPMICReader()
+
+
+@dataclass
+class RPIMeasurement(MachineMeasurement):
+    """Energy measured at the Raspberry Pi 5 PMIC. Units: mJ.
+
+    Attributes:
+        machine_energy_mj: Summed across every rail that reports both a current
+            and a voltage, twelve on a Model B Rev 1.0. Whole-board, so it
+            includes the wireless, HDMI and I/O rails and is larger than the sum
+            of the two fields below.
+        cpu_energy_mj: The SoC core rail, `VDD_CORE`.
+        dram_energy_mj: The two DRAM rails, `DDR_VDD2` and `DDR_VDDQ`, combined.
+    """
+
+    cpu_energy_mj: float | None = None
+    dram_energy_mj: float | None = None
+
+
+class Command(enum.Enum):
+    """Commands accepted by the polling process."""
+
+    READ = "read"
+    STOP = "stop"
+
+
+class RaspberryPi(Machine):
+    """Whole-machine energy for a Raspberry Pi 5, measured at the PMIC."""
+
+    def __init__(
+        self,
+        reader: PMICReader | None = None,
+        poll_interval_s: float = _DEFAULT_POLL_INTERVAL_S,
+    ) -> None:
+        """Initialize a Raspberry Pi energy monitor.
+
+        Args:
+            reader: PMIC reader to use. Defaults to the mailbox reader, falling
+                back to `vcgencmd` when `/dev/vcio` is not usable.
+            poll_interval_s: Seconds between PMIC samples.
+        """
+        self.reader = reader if reader is not None else default_reader()
+        self.poll_interval_s = poll_interval_s
+        self.measurement_states: dict[str, RPIMeasurement] = {}
+        self.available_metrics: set[str] | None = None
+
+        # Fail with a clear message rather than starting a polling process that
+        # can only ever produce zeros.
+        try:
+            rails = self.reader.read_rail_power_mw()
+        except PMICReadError as exc:
+            raise ZeusRaspberryPiInitError(str(exc)) from exc
+        if not rails:
+            raise ZeusRaspberryPiInitError(
+                "The PMIC ADC reported no rail with both a current and a voltage "
+                "channel. Per-rail energy measurement needs a board whose PMIC "
+                "exposes both."
+            )
+        self.rails = sorted(rails)
+
+        self.command_queue: mp.Queue = mp.Queue()
+        self.result_queue: mp.Queue = mp.Queue()
+        self.process = mp.Process(
+            target=_polling_process_async_wrapper,
+            args=(
+                self.command_queue,
+                self.result_queue,
+                self.reader,
+                self.poll_interval_s,
+            ),
+            daemon=True,
+        )
+        self.process.start()
+        atexit.register(self._stop_process)
+
+    def _stop_process(self) -> None:
+        """Stop the polling process."""
+        with contextlib.suppress(Exception):
+            self.command_queue.put_nowait(Command.STOP)
+        self.process.join(timeout=1.0)
+        if self.process.is_alive():
+            self.process.kill()
+
+    def get_available_metrics(self) -> set[str]:
+        """Return the measurement fields this board actually populates."""
+        if self.available_metrics is None:
+            result = self.get_total_energy_consumption()
+            self.available_metrics = {name for name, value in asdict(result).items() if value is not None}
+        return self.available_metrics
+
+    def get_total_energy_consumption(self, timeout: float = 15.0) -> RPIMeasurement:
+        """Return cumulative board energy since the monitor started. Units: mJ."""
+        self.command_queue.put(Command.READ)
+        return self.result_queue.get(timeout=timeout)
+
+    def begin_window(self, key: str, restart: bool = False) -> None:
+        """Begin a measurement interval labeled with `key`.
+
+        Args:
+            key: Unique name of the measurement window.
+            restart: If True and the window already exists, cancel the existing
+                window and start a new one.
+        """
+        if key in self.measurement_states:
+            if not restart:
+                raise KeyError(f"Measurement window '{key}' already exists")
+            self.measurement_states.pop(key)
+        self.measurement_states[key] = self.get_total_energy_consumption()
+
+    def end_window(self, key: str) -> RPIMeasurement:
+        """End a measurement window and return the energy consumed. Units: mJ."""
+        try:
+            start = self.measurement_states.pop(key)
+        except KeyError:
+            raise KeyError(f"Measurement window '{key}' does not exist") from None
+        return self.get_total_energy_consumption() - start
+
+
+def _accumulate(
+    cumulative: RPIMeasurement,
+    prev_power: dict[str, float],
+    power: dict[str, float],
+    dt: float,
+) -> None:
+    """Trapezoidally integrate one sampling interval into `cumulative`.
+
+    Trapezoidal rather than rectangular because at 10 Hz the power on this board
+    can change substantially within one interval, a core leaving idle moves the
+    core rail by several watts, and taking either endpoint alone biases the
+    integral in a load-dependent direction.
+    """
+
+    def rail_energy(rail_names: tuple[str, ...]) -> float | None:
+        total = 0.0
+        seen = False
+        for rail in rail_names:
+            if rail in power and rail in prev_power:
+                total += 0.5 * (power[rail] + prev_power[rail]) * dt
+                seen = True
+        return total if seen else None
+
+    cpu = rail_energy(_CPU_RAILS)
+    if cpu is not None:
+        cumulative.cpu_energy_mj = (cumulative.cpu_energy_mj or 0.0) + cpu
+
+    dram = rail_energy(_DRAM_RAILS)
+    if dram is not None:
+        cumulative.dram_energy_mj = (cumulative.dram_energy_mj or 0.0) + dram
+
+    shared = power.keys() & prev_power.keys()
+    if shared:
+        total = sum(0.5 * (power[r] + prev_power[r]) * dt for r in shared)
+        cumulative.machine_energy_mj += total
+
+
+def _polling_process_async_wrapper(
+    command_queue: mp.Queue,
+    result_queue: mp.Queue,
+    reader: PMICReader,
+    poll_interval_s: float,
+) -> None:
+    """Function wrapper for the asynchronous energy polling process."""
+    asyncio.run(_polling_process_async(command_queue, result_queue, reader, poll_interval_s))
+
+
+async def _polling_process_async(
+    command_queue: mp.Queue,
+    result_queue: mp.Queue,
+    reader: PMICReader,
+    poll_interval_s: float,
+) -> None:
+    """Continuously integrate PMIC power into cumulative energy until told to stop."""
+    probe = reader.read_rail_power_mw()
+    cumulative = RPIMeasurement(
+        machine_energy_mj=0.0,
+        cpu_energy_mj=0.0 if any(r in probe for r in _CPU_RAILS) else None,
+        dram_energy_mj=0.0 if any(r in probe for r in _DRAM_RAILS) else None,
+    )
+
+    prev_power = probe
+    prev_ts = time.monotonic()
+
+    while True:
+        try:
+            power = reader.read_rail_power_mw()
+        except PMICReadError:
+            # A transient read failure should not lose the accumulated total;
+            # reuse the previous sample for this interval and try again.
+            power = prev_power
+        now = time.monotonic()
+        _accumulate(cumulative, prev_power, power, now - prev_ts)
+        prev_power = power
+        prev_ts = now
+
+        try:
+            command = await asyncio.to_thread(command_queue.get, timeout=poll_interval_s)
+        except Empty:
+            continue
+
+        if command == Command.STOP:
+            break
+        if command == Command.READ:
+            result_queue.put(cumulative)
+
+
+def rpi_is_available() -> bool:
+    """Return whether this is a Raspberry Pi whose PMIC ADC can actually be read.
+
+    Boards before the Pi 5 do not expose per-rail ADC channels, so the model
+    string alone is not enough and the read has to return rails.
+    """
+    if sys.platform != "linux" or platform.machine() not in ("aarch64", "arm64"):
+        return False
+
+    model = Path("/proc/device-tree/model")
+    try:
+        if "raspberry pi" not in model.read_bytes().decode(errors="ignore").lower():
+            return False
+    except OSError:
+        return False
+
+    reader: PMICReader | None = None
+    try:
+        reader = default_reader()
+        return bool(reader.read_rail_power_mw())
+    except PMICReadError:
+        return False
+    finally:
+        if reader is not None:
+            reader.close()


### PR DESCRIPTION
Closes the plan in #273. Shape follows what you proposed there: inheritance, with `machine_energy_mj` on the base and per-platform subclasses adding what their hardware can actually separate.

## Why a new abstraction rather than `soc`

Zeus meters GPUs, CPUs and SoCs. All three sit on the die, so none can account for what the rest of the box draws. The Pi's PMIC is a separate chip metering board rails, which is a different kind of thing, and the same is true of a BMC over IPMI or a wall meter. `zeus.device.machine` is that sibling.

`MachineMeasurement` carries `machine_energy_mj` and nothing else, because whole-machine energy is the one figure any of these sources can give. An IPMI backend that only knows the chassis total does not have to invent domains it cannot see. `RPIMeasurement` adds `cpu_energy_mj` and `dram_energy_mj`.

## What the Pi backend does

Twelve rails carry both a current and a voltage channel on a Model B Rev 1.0. `EXT5V` and `BATT` report a voltage only, so they cannot yield power and are excluded. `machine_energy_mj` is summed over all twelve, so it is genuinely whole-board and larger than the sum of the CPU and DRAM fields.

There is no cumulative energy counter in the hardware, so power is sampled and integrated trapezoidally at 10 Hz, the same shape as the Jetson backend.

## No subprocess per sample

You said you felt strongly about this, so I want to be exact about what it bought.

`strace` shows `vcgencmd pmic_read_adc` doing two things: one `openat` of `/dev/vcio` and one `_IOWR(100, 0, 8)` mailbox property ioctl under firmware tag `0x00030080`. `VcioPMICReader` does that directly on a descriptor opened once.

Measured over 50 reads on the board: **22.6 ms per sample against 23.9 ms for the subprocess, about 5%.** The firmware's own ADC sweep dominates and nothing in userspace touches it. So the reason to prefer it is that it does not fork a process into the middle of the workload being measured, not that it is fast. Where `/dev/vcio` is not reachable, for example in a container that does not map it, it falls back to `vcgencmd` automatically.

`/dev/vcio` is `root:video` mode 0660, so the `video` group is enough and no root is needed, unlike RAPL.

## Hardware verification

Raspberry Pi 5 Model B Rev 1.0, five workloads, reader confirmed as the mailbox one:

| workload | mean power | machine | cpu | dram | dram/cpu |
|---|---|---|---|---|---|
| idle | 2.06 W | 12.37 J | 4.23 J | 0.012 J | 0.0028 |
| spin, 1 core | 2.94 W | 17.65 J | 9.45 J | 0.000 J | 0.0000 |
| spin, 4 cores | 5.51 W | 33.10 J | 24.90 J | 0.010 J | 0.0004 |
| memcpy, 1 core | 3.22 W | 19.44 J | 10.15 J | 0.571 J | 0.0562 |
| memcpy, 4 cores | 4.29 W | 26.58 J | 16.98 J | 0.680 J | 0.0400 |

A four-core memcpy moves the DRAM rails **about 96 times harder relative to the core rail** than a four-core register spin does. That is the check that matters: if DRAM were the core rail relabelled, the ratio would not move.

## A correction to something I said on the issue

I claimed DDR_VDDQ leaves its current channel at zero even under load. **That is wrong.** Characterised at ~50 Hz, 150 samples per condition: under decode, DDR_VDD2 is non-zero in 148 of 150 samples and DDR_VDDQ in 135 of 150, so VDDQ carries roughly 14% of DRAM power. Both rails read exact zero at idle, which is the ADC at low current rather than the rail, and it means a low sampling rate underestimates DRAM energy on a lightly loaded board. The code and the test fixture reflect the corrected behaviour, and the fixture is now captured under load rather than at idle.

## Checks

Both CI legs, locally:

- Python 3.10: `1696 passed, 5 skipped`
- Python 3.13: `1696 passed, 5 skipped`
- `ruff format --check zeus tests`, `ruff check zeus`, `ty check zeus`: clean on both
- `mkdocs build --strict`: clean

24 new tests, none of which need a Pi: the parser runs against captured `pmic_read_adc` output and the monitor runs against a fake reader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added whole-machine power measurement support for Raspberry Pi 5 devices.
  * Added machine energy metrics for total, CPU, and DRAM consumption.
  * Added labeled measurement windows and configurable sampling intervals.
  * Added automatic fallback to `vcgencmd` when direct mailbox access is unavailable.

* **Documentation**
  * Added Raspberry Pi whole-machine power measurement guidance and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->