### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,8 @@
-# this is the dependabot file
-
 version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# this is the dependabot file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Since older versions are throwing warnings in GitHub actions.

## Contribution policy

- [x] I have read and agree to follow the [contribution policy](https://github.com/ml-energy/zeus/blob/master/CONTRIBUTING.md), including its AI usage policy.

## Summary

<!-- Describe the change and its purpose in your own words. Please be concise. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Configured monthly automated checks for GitHub Actions updates.
  - GitHub Actions update proposals are subject to a seven-day cooldown period.
  - Dependabot now monitors GitHub Actions from the repository root, helping keep workflow dependencies current while spacing out update proposals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->